### PR TITLE
Use a /tmp subdirectory to hold the certificate and key when running via Docker Machine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ generate a `ccn_proxy:0.1` image.
 You will need a local cert and key to start `ccn_proxy`.  You can run
 `make generate-certificate` to generate them if you don't already have them.
 
-You can also just run `make run-local` which will build a build image, use
+You can also just run `make run` which will build a build image, use
 the build image to build the `ccn_proxy` image, generate a self-signed
 certificate + key if you don't already have them, and start the `ccn_proxy` with
 the self-signed certificate and key bind-mounted into the correct location
-automatically.
+automatically.  This works with local Docker installations and Docker Machine
+installations.

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euxo pipefail
 
 make generate-certificate
 
@@ -15,7 +15,7 @@ if [ -z "${DOCKER_HOST-}" ]; then
 	   --skip-netmaster-verification
 else
     echo "Copying certificates to docker-machine:"
-    cert_path="/home/docker/ccn_proxy/"
+    cert_path="/tmp/ccn_proxy/"
 
     docker-machine ssh $DOCKER_MACHINE_NAME mkdir -p $cert_path
     docker-machine scp './local_certs/local.key' $DOCKER_MACHINE_NAME:$cert_path


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>