### PR TITLE
Removed requirement for upstream netmaster to be TLS + all related code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # CCN Proxy
 
 This proxy provides authentication via Active Directory and authorization via
-RBAC before forwarding requests to an upstream `netmaster` it is paired with.
-
-It is TLS-only, and it will only talk to a TLS-enabled `netmaster`.  It supports
-self-signed certificates both for itself and for the upstream `netmaster`. If
-the upstream `netmaster` is using a self-signed certificate, you will need to
-run it with the `--skip-netmaster-verification` flag.
+RBAC before forwarding requests to an upstream `netmaster`. It is TLS-only,
+and it will only talk to a non-TLS `netmaster`.  Future versions will allow
+or potentially require TLS-only communication with `netmaster`.
 
 ## Building
 
@@ -21,7 +18,7 @@ You will need a local cert and key to start `ccn_proxy`.  You can run
 `make generate-certificate` to generate them if you don't already have them.
 
 You can also just run `make run` which will build a build image, use
-the build image to build the `ccn_proxy` image, generate a self-signed
+the build image to build the minimalist `ccn_proxy` image, generate a self-signed
 certificate + key if you don't already have them, and start the `ccn_proxy` with
 the self-signed certificate and key bind-mounted into the correct location
 automatically.  This works with local Docker installations and Docker Machine

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,8 +12,7 @@ if [ -z "${DOCKER_HOST-}" ]; then
      -p 9999:9999 \
 	   -v $PWD/local_certs:/certs ccn_proxy:devbuild \
 	   --tls-key-file=/certs/local.key \
-	   --tls-certificate=/certs/cert.pem \
-	   --skip-netmaster-verification
+	   --tls-certificate=/certs/cert.pem
 else
     echo "Copying certificates to docker-machine:"
     cert_path="/tmp/ccn_proxy/"
@@ -27,6 +26,5 @@ else
      -p 9999:9999 \
 	   -v $cert_path:/certs ccn_proxy:devbuild \
 	   --tls-key-file=/certs/local.key \
-	   --tls-certificate=/certs/cert.pem \
-	   --skip-netmaster-verification
+	   --tls-certificate=/certs/cert.pem
 fi


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>