### PR TITLE
/login endpoint now returns the token in the JSON response body rather than in a response header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # binaries and binary directories
 build/output
-ccn_proxy/ccn_proxy
+ccn_proxy
 
 # local development certificates and keys
 local_certs

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -163,7 +163,7 @@ func (s *Server) Serve() {
 
 	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
 
-	s.listener, err = tls.Listen("tcp", s.config.NetmasterAddress, tlsConfig)
+	s.listener, err = tls.Listen("tcp", s.config.ListenAddress, tlsConfig)
 	if err != nil {
 		log.Fatalln(err)
 		return


### PR DESCRIPTION
Fixed a bug in the last commit where the netmaster address was being used instead of the listen address (oops)

Fixes #11 