### PR TITLE
Added some basic systemtests for the proxy package + a MockServer for mocking netmaster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ build: checks
 checks:
 	@bash ./scripts/checks.sh
 
+# ci does everything necessary for a Github PR-triggered CI run
+ci: checks test
+
 # generate-certificate generates a local key and cert for running the proxy.
 # if an existing certificate and key exist, it will do nothing.
 # if either of them do not exist, they will both be recreated.
@@ -30,4 +33,12 @@ godep:
 run: build generate-certificate
 	@bash ./scripts/run.sh
 
-.PHONY: all build checks generate-certificate godep run
+# systemtests runs the system tests suite.
+systemtests:
+	go get gopkg.in/check.v1
+	go test -v -timeout 1m ./systemtests -check.v
+
+# test runs ALL the test suites.
+test: systemtests
+
+.PHONY: all build checks ci generate-certificate godep run systemtests test

--- a/README.md
+++ b/README.md
@@ -12,7 +12,21 @@ Running `make` will generate a `ccn_proxy:devbuild` image.
 You can also specify a version, e.g., `BUILD_VERSION=0.1 make`.  This will
 generate a `ccn_proxy:0.1` image.
 
-## Testing locally
+## Running Tests
+
+Just run `make test`.  The proxy functionality is part of the `proxy` package
+and there is also a `MockServer` available in the `systemtests` directory
+which can pretend to be `netmaster` for the purposes of testing.  This allows
+us to mock the parts of `netmaster` we need (mainly that a given endpoint
+returns some expected JSON response) without the burden of actually compiling
+and running a full `netmaster` binary and all of its dependencies plus creating
+the necessary networks, tenants, etc. to get realistic responses from it.
+
+CCN's future end-to-end testing will cover a real `ccn_proxy` binary talking to
+a real `netmaster` binary so there's no point duplicating that here in our own
+testing.
+
+## Local Development
 
 You will need a local cert and key to start `ccn_proxy`.  You can run
 `make generate-certificate` to generate them if you don't already have them.
@@ -42,9 +56,9 @@ Subsequent requests must pass this token along in a `X-Auth-Token` request
 header.  All non-login requests are simply passed on to the `netmaster` if
 authentication and authorization are both successful.
 
-Example of a full request cycle:
+### Example of a full request cycle:
 
-1. A request for `/api/v1/networks` is sent in with a token in the `X-Auth-Token` header
+1. A request for `/api/v1/networks/` is sent in with a token in the `X-Auth-Token` header
 1. The user represented by the token is authenticated against a local DB or LDAP / Active Directory
 1. An authorization check is performed to see if the user is allowed to access the resource in question (networks)
 1. If both authentication and authorization are successful, the request is proxied to `netmaster`
@@ -55,5 +69,5 @@ request w. token ---> ccn_proxy ---> authorization ----> request forwarded to ne
                                                                                         \
                                                                                          netmaster
                                                                                         /
-<------- results filtered based on token and returned to client <------- proxy --------
+<----- results filtered based on token and returned to client <----- ccn_proxy --------
 ```

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,6 +1,9 @@
 package common
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
 
 // IsEmpty checks if the given string is empty or not
 // params:
@@ -9,4 +12,11 @@ import "strings"
 //  true if the string is empty otherwise false
 func IsEmpty(str string) bool {
 	return len(strings.TrimSpace(str)) == 0
+}
+
+// SetJSONContentType sets the Content-Type header to JSON.
+func SetJSONContentType(w http.ResponseWriter) {
+	// the charset here is to work around a bug where Chrome does not parse JSON data properly:
+	// https://bugs.chromium.org/p/chromium/issues/detail?id=438464
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,17 +2,16 @@
 
 set -euxo pipefail
 
-make generate-certificate
-
 # if DOCKER_HOST is not set, just run the image locally.
 # otherwise, scp the key and cert over to the docker machine before starting it.
 if [ -z "${DOCKER_HOST-}" ]; then
     echo "Running on local machine:"
     docker run --rm \
-     -p 9999:9999 \
+	   -p 9999:9999 \
 	   -v $PWD/local_certs:/certs ccn_proxy:devbuild \
 	   --tls-key-file=/certs/local.key \
-	   --tls-certificate=/certs/cert.pem
+	   --tls-certificate=/certs/cert.pem \
+	   --data-store-address=etcd://localhost:2379
 else
     echo "Copying certificates to docker-machine:"
     cert_path="/tmp/ccn_proxy/"
@@ -23,8 +22,9 @@ else
 
     echo "Running on Docker Machine:"
     docker run --rm \
-     -p 9999:9999 \
+	   -p 9999:9999 \
 	   -v $cert_path:/certs ccn_proxy:devbuild \
 	   --tls-key-file=/certs/local.key \
-	   --tls-certificate=/certs/cert.pem
+	   --tls-certificate=/certs/cert.pem \
+	   --data-store-address=etcd://localhost:2379
 fi

--- a/systemtests/basic_test.go
+++ b/systemtests/basic_test.go
@@ -1,0 +1,95 @@
+package systemtests
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/contiv/ccn_proxy/proxy"
+	. "gopkg.in/check.v1"
+)
+
+// TODO: the usernames and passwords here are currently hardcoded in lieu of
+//       having a package/datastore for doing local user management.
+//       See Test() in init_test.go for where that would be done.
+
+// TestLogin tests that valid credentials successfully authenticate and that
+// invalid credentials result in failed authentication.
+func (s *systemtestSuite) TestLogin(c *C) {
+	runTest(func(p *proxy.Server, ms *MockServer) {
+		//
+		// valid credentials
+		//
+		token, resp, err := login(adminUsername, adminPassword)
+		c.Assert(err, IsNil)
+		c.Assert(resp.StatusCode, Equals, 200)
+		c.Assert(len(token), Not(Equals), 0)
+
+		//
+		// invalid credentials
+		//
+		token, resp, err = login("foo", "bar")
+
+		// TODO: this error should be nil, but it will not be if AD is
+		// not running.  once we have an AD setup or a mock AD server,
+		// we should fix this.
+		c.Assert(err, Not(IsNil))
+		c.Assert(resp.StatusCode, Equals, 401)
+		c.Assert(len(token), Equals, 0)
+	})
+}
+
+// TestRequestProxying tests that authenticated requests are proxied to the mock
+// server and the response is returned properly.
+func (s *systemtestSuite) TestRequestProxying(c *C) {
+	runTest(func(p *proxy.Server, ms *MockServer) {
+
+		data := `{"foo":"bar"}`
+		endpoint := "/api/v1/networks/"
+
+		ms.AddHardcodedResponse(endpoint, []byte(data))
+
+		token := adminToken(c)
+
+		resp, body := proxyGet(c, token, endpoint)
+		c.Assert(data, Equals, string(body))
+
+		// check that the Content-Type header was set properly.
+		// we need to add a custom charset to work around a Chrome bug:
+		// https://bugs.chromium.org/p/chromium/issues/detail?id=438464
+		headerFound := false
+		for name, headers := range resp.Header {
+			if name == "Content-Type" {
+				c.Assert(len(headers), Equals, 1)
+				c.Assert(headers[0], Equals, "application/json; charset=utf-8")
+				headerFound = true
+				break
+			}
+		}
+
+		c.Assert(headerFound, Equals, true)
+	})
+}
+
+// TestPOSTBody tests that the body of a POST request is received by the mock
+// server exactly as we sent it to the proxy.
+func (s *systemtestSuite) TestPOSTBody(c *C) {
+	runTest(func(p *proxy.Server, ms *MockServer) {
+
+		data := `{"foo":"bar"}`
+		endpoint := "/api/v1/networks/foo/"
+
+		// this handler sends the request body back as the response body
+		ms.AddHandler(endpoint, func(w http.ResponseWriter, req *http.Request) {
+			body, err := ioutil.ReadAll(req.Body)
+			c.Assert(err, IsNil)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write(body)
+		})
+
+		token := adminToken(c)
+
+		_, responseBody := proxyPost(c, token, endpoint, []byte(data))
+		c.Assert(string(responseBody), Equals, data)
+	})
+}

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -1,0 +1,244 @@
+package systemtests
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/contiv/ccn_proxy/proxy"
+
+	. "gopkg.in/check.v1"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const (
+	adminUsername = "admin"
+	adminPassword = "admin"
+
+	opsUsername = "ops"
+	opsPassword = "ops"
+)
+
+func Test(t *testing.T) {
+
+	// TODO: once we support a datastore to hold local users, add default
+	//       local users for admin and ops for testing purposes.  The users
+	//       added here will exist across all of the tests that run.
+	//       We should create admin and ops users using the constants above.
+
+	TestingT(t)
+}
+
+type systemtestSuite struct{}
+
+var _ = Suite(&systemtestSuite{})
+
+// ===== TEST PROXY SERVER ======================================================
+
+const proxyHost = "localhost:50000"
+const netmasterHost = "localhost:60000"
+
+// NewTestProxy returns a running proxy server
+func NewTestProxy() *proxy.Server {
+	p := proxy.NewServer(&proxy.Config{
+		Name:    "CCN Proxy",
+		Version: "systemtests",
+
+		// NOTE: instead of hardcoding the two ports here, we could just
+		//       randomly bind to ports until we find two available ones.
+		//       we can cross that bridge if it's worth it.
+		NetmasterAddress: netmasterHost,
+		ListenAddress:    proxyHost,
+
+		// cert and key path are relative to /systemtests and since
+		// `generate-certificates` is a make dependency, we can assume they exist
+		TLSCertificate: "../local_certs/cert.pem",
+		TLSKeyFile:     "../local_certs/local.key",
+	})
+	p.DisableKeepalives()
+	go p.Serve()
+
+	return p
+}
+
+// ===== MISC FUNCTIONS =========================================================
+
+// runTest is a convenience function which encapsulates the logic of creating an
+// instance of proxy.Server and setting its upstream to an instance of MockServer.
+// running each test inside of a runTest() call guarantees that no routes or
+// shenanigans from any previous tests are present.
+func runTest(f func(*proxy.Server, *MockServer)) {
+	p := NewTestProxy()
+	ms := NewMockServer()
+
+	// TODO: there is a race condition here regarding the goroutines where
+	//       http.Serve() is eventually called on the http.Server objects
+	//       created by NewTestProxy() and NewMockServer() above. Serve()
+	//       does not provide any notification mechanism for when it's ready
+	//       and it blocks when called, so there will be a very short window
+	//       between us starting the proxy and mock servers and them actually
+	//       being available to handle requests.
+	//
+	//       This ONLY affects the testing case and does not matter for the
+	//       proxy server in general.
+	//
+	//       We could send HTTP requests in a loop until one succeeds on
+	//       each server or something, but this is an acceptable stopgap
+	//       for now.
+	time.Sleep(25 * time.Millisecond)
+
+	f(p, ms)
+
+	ms.Stop()
+	p.Stop()
+
+	time.Sleep(25 * time.Millisecond)
+}
+
+// login returns the user's token or returns an error if authentication fails.
+func login(username, password string) (string, *http.Response, error) {
+	type loginBody struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+
+	lb := loginBody{
+		Username: username,
+		Password: password,
+	}
+
+	loginBytes, err := json.Marshal(&lb)
+	if err != nil {
+		return "", nil, err
+	}
+
+	resp, data, err := insecurePostJSONBody("", proxy.LoginPath, loginBytes)
+	if err != nil {
+		return "", resp, err
+	}
+
+	lr := proxy.LoginResponse{}
+	err = json.Unmarshal(data, &lr)
+	if err != nil {
+		return "", resp, err
+	}
+
+	return lr.Token, resp, nil
+}
+
+// loginAs has the same functionality as login() but asserts rather than
+// returning any errors.  You can use this to login when *not* testing login
+// functionality if the adminToken() and opsToken() functions aren't more useful.
+func loginAs(c *C, username, password string) string {
+	token, resp, err := login(username, password)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, 200)
+	c.Assert(len(token), Not(Equals), 0)
+
+	return token
+}
+
+// adminToken logs in as the default admin user and returns a token or asserts.
+func adminToken(c *C) string {
+	return loginAs(c, adminUsername, adminPassword)
+}
+
+// opsToken logs in as the default ops user and returns a token or asserts.
+func opsToken(c *C) string {
+	return loginAs(c, opsUsername, opsPassword)
+}
+
+var insecureTestClient *http.Client
+
+// insecureClient returns an insecure HTTPS client for talking to the proxy
+// during testing.  this function is memoized and only incurs overhead on the
+// first call.
+func insecureClient() *http.Client {
+	if nil == insecureTestClient {
+		insecureTestClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	}
+
+	return insecureTestClient
+}
+
+// proxyGet is a convenience function which sends an insecure HTTPS GET
+// request to the proxy.
+func proxyGet(c *C, token, path string) (*http.Response, []byte) {
+	url := "https://" + proxyHost + path
+
+	log.Info("GET to ", url)
+
+	req, err := http.NewRequest("GET", url, nil)
+	c.Assert(err, IsNil)
+
+	if len(token) > 0 {
+		log.Println("Setting X-Auth-token to:", token)
+		req.Header.Set("X-Auth-Token", token)
+	}
+
+	resp, err := insecureClient().Do(req)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, 200)
+
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+
+	return resp, data
+}
+
+// proxyPost is a convenience function which sends an insecure HTTPS POST
+// request with the specified body to the proxy.
+func proxyPost(c *C, token, path string, body []byte) (*http.Response, []byte) {
+	resp, body, err := insecurePostJSONBody(token, path, body)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode/100, Equals, 2) // 2xx is okay
+
+	return resp, body
+}
+
+// insecurePostBody sends an insecure HTTPS POST request with the specified
+// JSON payload as the body.
+func insecurePostJSONBody(token, path string, body []byte) (*http.Response, []byte, error) {
+	url := "https://" + proxyHost + path
+
+	log.Info("POST to ", url)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		log.Debugf("POST request creation failed: %s", err)
+		return nil, nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if len(token) > 0 {
+		log.Println("Setting X-Auth-token")
+		req.Header.Set("X-Auth-Token", token)
+	}
+
+	resp, err := insecureClient().Do(req)
+	if err != nil {
+		log.Debugf("POST request failed: %s", err)
+		return nil, nil, err
+	}
+
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Debugf("Failed to read response body: %s", err)
+		return nil, nil, err
+	}
+
+	return resp, data, nil
+}

--- a/systemtests/mock_server.go
+++ b/systemtests/mock_server.go
@@ -1,0 +1,86 @@
+package systemtests
+
+import (
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/contiv/ccn_proxy/common"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// NewMockServer returns a configured, initialized, and running MockServer which
+// can have routes added even though it's already running. Call Stop() to stop it.
+func NewMockServer() *MockServer {
+	ms := &MockServer{}
+	ms.Init()
+	go ms.Serve()
+
+	return ms
+}
+
+// MockServer is a server which we can program to behave like netmaster for
+// testing purposes.
+type MockServer struct {
+	listener net.Listener   // the actual HTTPS listener
+	mux      *http.ServeMux // a custom ServeMux we can add routes onto later
+	stopChan chan bool      // used to shut down the server
+	wg       sync.WaitGroup // used to avoid a race condition when shutting down
+}
+
+// Init just sets up the stop channel and our custom ServeMux
+func (ms *MockServer) Init() {
+	ms.stopChan = make(chan bool, 1)
+	ms.mux = http.NewServeMux()
+}
+
+// AddHardcodedResponse registers a HTTP handler func for `path' that returns `body'.
+func (ms *MockServer) AddHardcodedResponse(path string, body []byte) {
+	ms.mux.HandleFunc(path, func(w http.ResponseWriter, req *http.Request) {
+		common.SetJSONContentType(w)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	})
+}
+
+// AddHandler allows adding a custom route handler to our custom ServeMux
+func (ms *MockServer) AddHandler(path string, f func(http.ResponseWriter, *http.Request)) {
+	ms.mux.HandleFunc(path, f)
+}
+
+// Serve starts the mock server using the custom ServeMux we set up.
+func (ms *MockServer) Serve() {
+	var err error
+
+	ms.listener, err = net.Listen("tcp", netmasterHost)
+	if err != nil {
+		log.Fatal("net.Listen: ", err)
+		return
+	}
+
+	server := &http.Server{Handler: ms.mux}
+
+	// because of the tight time constraints around starting/stopping the
+	// mock server when running tests and the fact that lingering client
+	// connections can cause the server not to shut down in a timely
+	// manner, we will just disable keepalives entirely here.
+	server.SetKeepAlivesEnabled(false)
+
+	ms.wg.Add(1)
+	go func() {
+		server.Serve(ms.listener)
+		ms.wg.Done()
+	}()
+
+	<-ms.stopChan
+
+	ms.listener.Close()
+
+	ms.wg.Wait()
+}
+
+// Stop stops the mock server.
+func (ms *MockServer) Stop() {
+	ms.stopChan <- true
+}


### PR DESCRIPTION
Added `make ci`, `make test`, and `make systemtests` targets.

Addressed a race condition during shutdown of proxy.Serve()

Changed JSON response Content-Type header to include charset to work around a Chrome bug

Updated README.md

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

## Instructions

Just run `make test` to run the tests.  That's it!

## Misc.

Fixes #10