### PR TITLE
AuthZ: Endpoints to CCN proxy and API to the KV-store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,16 @@ systemtests:
 	go get gopkg.in/check.v1
 	go test -v -timeout 1m ./systemtests -check.v
 
-# test runs ALL the test suites.
-test: systemtests unit-tests
-
-# unit-tests runs all the unit test suites.
-unit-tests:
+# unittests runs all the unit tests
+unit-tests: 
+	USE_DATASTORE_ADDRESS=etcd://127.0.0.1:2379 go test -v -timeout 1m ./common/types/test -check.v
+	USE_DATASTORE_ADDRESS=etcd://127.0.0.1:2379 go test -run TestEtcd* -v -timeout 1m ./state -check.v
+	USE_DATASTORE_ADDRESS=consul://127.0.0.1:8500 go test -run TestConsul* -v -timeout 1m ./state -check.v
+	USE_DATASTORE_ADDRESS=etcd://127.0.0.1:2379 go test -v -timeout 1m ./state/test -check.v
 	USE_DATASTORE=consul go test -v -timeout 1m ./usermgmt -check.v
 	USE_DATASTORE=etcd   go test -v -timeout 1m ./usermgmt -check.v
+
+# test runs ALL the test suites.
+test: systemtests unit-tests
 
 .PHONY: all build checks ci generate-certificate godep run systemtests test unit-tests

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,10 +3,13 @@ package auth
 import (
 	"github.com/contiv/ccn_proxy/auth/ldap"
 	"github.com/contiv/ccn_proxy/auth/local"
+	"github.com/contiv/ccn_proxy/common"
 	ccnerrors "github.com/contiv/ccn_proxy/common/errors"
 	"github.com/contiv/ccn_proxy/common/types"
+	"github.com/contiv/ccn_proxy/state"
 
 	log "github.com/Sirupsen/logrus"
+	uuid "github.com/satori/go.uuid"
 )
 
 // Authenticate authenticates the user against local DB or AD using the given credentials
@@ -28,7 +31,6 @@ func Authenticate(username, password string) (string, error) {
 			return generateToken(userPrincipals, username) // ldap authentication succeeded!
 		}
 	}
-
 	return "", err // error from authentication
 }
 
@@ -50,4 +52,358 @@ func generateToken(principals []*types.Principal, username string) (string, erro
 	authZ.AddClaim("username", username)
 
 	return authZ.Stringify()
+}
+
+//
+// getPrincipal determines the principal ID and role for the given
+// user identified by their user name (for local users) or their
+// LDAP group name (for LDAP users)
+//
+// Parameters:
+//   principalName: name of the user whose principal ID and role is needed
+//   isLocal:  true indicates the user is local, false indicates user
+//             belongs to an LDAP group
+//
+// Return values:
+//   string: principal UUID
+//   string: primary role of the user
+//   error:  nil if successful
+//
+func getPrincipal(principalName string, isLocal bool) (string, string, error) {
+
+	// check local users and LDAP
+
+	// TODO: hardcoding dummy values till this becomes
+	// available
+	return "2222", "devops", nil
+}
+
+//
+// checkAccessClaim checks whether the granted role has desired level of access
+// which is specified as a role itself.
+//
+// Parameters:
+//  granted: role that is present in claim
+//  desired: access that is required, specified as a role
+//
+// Return values:
+//  error: nil if 'granted' role has 'desired' access, otherwise:
+//   ccnerrors.ErrUnauthorized: if 'granted' role doesn't have the 'desired' level of access
+//   ccnerrors.ErrUnsupportedType: if 'desired' is not a role type
+//
+func checkAccessClaim(granted types.RoleType, desired interface{}) error {
+
+	switch desired.(type) {
+	// A role check
+	case types.RoleType:
+		desiredRole := desired.(types.RoleType)
+		// Role hierarchy implicies that any role that is less or equal
+		// in value has the desired level of access.
+		if granted <= desiredRole {
+			return nil
+		}
+		log.Error("access denied for granted role:", granted.String(),
+			" desired role:", desiredRole.String())
+	// TODO: Add a case to explicitly check capability
+	default:
+		log.Errorf("unsupported type for authorization check, got: %#v, expecting: types.RoleType", desired)
+		return ccnerrors.ErrUnsupportedType
+	}
+
+	return ccnerrors.ErrUnauthorized
+}
+
+//
+// AddTenantAuthorization stores authorization claim(s) for a tenant for a
+// specific named principal in the KV store. Success of various tenant related
+// operations will depend on the named principal's capabilities, determined by
+// the role that is associated with the claim.
+//
+// This API must be called with role=admin authorization claim.
+//
+// Parameters:
+//  tenantName: tenant name
+//  principalName: Name of user for whom the authorization is to be added,
+//            Can either be a local user or an LDAP group.
+//  isLocal: true if the named principal is a local user, false if ldap group.
+//
+// Return values:
+//  types.Authorization: new authorization that was added
+//  error: nil if successful, else
+//    errors.NonExistentLocalUserError: if a local user doesn't exist
+//    errors.NonExistentLdapGroupError: if ldap group doesn't exist
+//    : error from state.InsertTenantAuthorization if adding a tenant authorization
+//      fails.
+//
+func AddTenantAuthorization(tokenStr, tenantName, principalName string,
+	isLocal bool) (types.Authorization, error) {
+
+	defer common.Untrace(common.Trace())
+
+	// convert token from string to Token type
+	token, err := ParseToken(tokenStr)
+	if err != nil {
+		return types.Authorization{}, ccnerrors.ErrParsingToken
+	}
+
+	// Check that caller has role=admin claim.
+	if err := token.CheckClaims(types.Admin); err != nil {
+		log.Error("unauthorized:unable to find role=admin claim:", err)
+		return types.Authorization{}, err
+	}
+
+	// use principal name to get principal UUID
+	principalID, _, err := getPrincipal(principalName, isLocal)
+	if err != nil {
+		return types.Authorization{}, err
+	}
+
+	// generate claim key
+	claimStr, err := GenerateClaimKey(types.Tenant(tenantName))
+	if err != nil {
+		log.Error("failed in generating claim:", err)
+		return types.Authorization{}, err
+	}
+
+	// create an authorization
+	sd, err := state.GetStateDriver()
+	if err != nil {
+		return types.Authorization{}, err
+	}
+	tenantAuthz := types.Authorization{
+		CommonState: types.CommonState{
+			StateDriver: sd,
+			ID:          uuid.NewV4().String(),
+		},
+		UUID:        uuid.NewV4().String(),
+		PrincipalID: principalID,
+		ClaimKey:    claimStr,
+		ClaimValue:  types.DerivedFromPrincipalRole,
+	}
+
+	// insert authorization
+	if err := state.InsertAuthorization(&tenantAuthz); err != nil {
+		log.Error("failed in adding tenant claim:", err)
+		return types.Authorization{}, err
+	}
+
+	log.Info("Adding tenant authorization successful")
+	return tenantAuthz, nil
+}
+
+//
+// DeleteTenantAuthorization deletes an authorization for a tenant.
+// This API must be called with role=Admin authorization claim.
+//
+// Parameters:
+//  tokenStr: authorization token
+//  authUUID: UUID of the tenant authorization object
+//
+// Return values:
+//  error: nil if successful, else
+//    types.UnauthorizedError: if caller isn't authorized to make this API
+//    call.
+//    : error from state.DeleteTenantAuthorization if deleting a tenant authorization
+//      fails
+//
+func DeleteTenantAuthorization(tokenStr, authUUID string) error {
+
+	defer common.Untrace(common.Trace())
+
+	// convert token from string to Token type
+	token, err := ParseToken(tokenStr)
+	if err != nil {
+		return ccnerrors.ErrParsingToken
+	}
+
+	// Return error if an authZ token isn't found or if it doesn't contain
+	// appropriate claim.
+	if err := token.CheckClaims(types.Admin); err != nil {
+		log.Error("unauthorized:unable to find role=admin claim:", err)
+		return err
+	}
+
+	// Return error if authorization doesn't exist
+	_, err = state.GetAuthorization(authUUID)
+	if err != nil {
+		log.Warn("failed to get authorization, err: ", err)
+		return err
+	}
+
+	// delete authz from the KV store
+	if err := state.DeleteAuthorization(authUUID); err != nil {
+		log.Warn("failed to delete tenant authZ")
+		return err
+	}
+
+	log.Info("Deleting tenant authorization successful")
+	return nil
+}
+
+//
+// GetTenantAuthorization returns a specific tenant authorization
+// identified by the authzUUID
+//
+// This API must be called with role=Admin authorization claim.
+//
+// Parameters:
+//  tokenStr: token string
+//  authzUUID : UUID of the authorization that needs to be returned
+//
+// Return values:
+//  error: nil if successful, else
+//    errors.ErrUnauthorized: if caller isn't authorized to make this API
+//    call.
+//    errors.ErrIllegalArguments: if auth doesn't match poolID
+//    : error from state.GetTenantAuthorization if auth lookup fails
+func GetTenantAuthorization(tokenStr, authzUUID string) (
+	types.Authorization, error) {
+
+	defer common.Untrace(common.Trace())
+
+	// convert token from string to Token type
+	token, err := ParseToken(tokenStr)
+	if err != nil {
+		return types.Authorization{}, ccnerrors.ErrParsingToken
+	}
+
+	// Return error if an authZ token isn't found or if it doesn't contain
+	// appropriate claim.
+	if err := token.CheckClaims(types.Admin); err != nil {
+		log.Error("unauthorized:unable to find role=admin claim:", err)
+		return types.Authorization{}, err
+	}
+
+	// Return error if authorization doesn't exist
+	authz, err := state.GetAuthorization(authzUUID)
+	if err != nil {
+		log.Warn("failed to get authorization; err:", err)
+		return types.Authorization{}, err
+	}
+
+	log.Info("Getting tenant authorization successful")
+	return authz, nil
+
+}
+
+//
+// UpdateTenantAuthorization updates an authorization in the KV store
+//
+// This API must be called with role=admin authorization claim.
+//
+// Parameters:
+//  tenantName: tenant name
+//  principalName: User for whom the authorization is to be updated,
+//            Can either be a local user or an LDAP group.
+//  isLocal: true if the user is a local user, false if ldap group.
+//
+// Return values:
+//  types.Authorization: updated authorization instance
+//  error: nil if successful, else
+//    : error from state.DeleteTenantAuthorization if deleting a tenant authorization
+//      fails.
+//    : error from state.InsertTenantAuthorization if adding a tenant authorization
+//      fails.
+//
+func UpdateTenantAuthorization(tokenStr, authzUUID, tenantName,
+	principalName string, isLocal bool) (types.Authorization, error) {
+
+	defer common.Untrace(common.Trace())
+
+	// convert token from string to Token type
+	token, err := ParseToken(tokenStr)
+	if err != nil {
+		return types.Authorization{}, ccnerrors.ErrParsingToken
+	}
+
+	// Check that caller has role=admin claim.
+	if err := token.CheckClaims(types.Admin); err != nil {
+		log.Error("unauthorized:unable to find role=admin claim:", err)
+		return types.Authorization{}, err
+	}
+
+	// use principal name to get principal UUID
+	principalID, _, err := getPrincipal(principalName, isLocal)
+	if err != nil {
+		return types.Authorization{}, err
+	}
+
+	// generate claim key
+	claimStr, err := GenerateClaimKey(types.Tenant(tenantName))
+	if err != nil {
+		log.Error("failed in generating claim:", err)
+		return types.Authorization{}, err
+	}
+
+	// create an authorization
+	sd, err := state.GetStateDriver()
+	if err != nil {
+		return types.Authorization{}, err
+	}
+	tenantAuthz := types.Authorization{
+		CommonState: types.CommonState{
+			StateDriver: sd,
+			ID:          uuid.NewV4().String(),
+		},
+		UUID:        authzUUID,
+		PrincipalID: principalID,
+		ClaimKey:    claimStr,
+		ClaimValue:  types.DerivedFromPrincipalRole,
+	}
+
+	// delete authz from the KV store
+	if err := state.DeleteAuthorization(authzUUID); err != nil {
+		log.Warn("failed to delete tenant authz, err:", err)
+		return types.Authorization{}, ccnerrors.ErrUpdateAuthorization
+	}
+
+	// insert updated authorization
+	if err := state.InsertAuthorization(&tenantAuthz); err != nil {
+		log.Error("failed in adding tenant authz, err:", err)
+		return types.Authorization{}, ccnerrors.ErrUpdateAuthorization
+	}
+
+	log.Info("Updating tenant authorization successful")
+	return tenantAuthz, nil
+}
+
+//
+// ListTenantAuthorizations returns all tenant authorizations.
+//
+// This API must be called with role=Admin authorization claim.
+//
+// Parameters:
+//  tokenStr: token string
+//
+// Return values:
+//  error: nil if successful, else
+//    errors.ErrUnauthorized: if caller isn't authorized to make this API
+//    call.
+//    : error from state.ListTenantAuthorizations if auth lookup fails
+//
+func ListTenantAuthorizations(tokenStr string) ([]types.Authorization, error) {
+
+	defer common.Untrace(common.Trace())
+
+	// convert token from string to Token type
+	token, err := ParseToken(tokenStr)
+	if err != nil {
+		return nil, ccnerrors.ErrParsingToken
+	}
+
+	// Check that caller has role=admin claim.
+	if err := token.CheckClaims(types.Admin); err != nil {
+		log.Error("unauthorized:unable to find role=admin claim:", err)
+		return nil, err
+	}
+
+	// read all authorizations
+	tenantAuths, err := state.ListAuthorizations()
+	if err != nil {
+		log.Error("failed to list all authorizations, err:", err)
+		return nil, err
+	}
+
+	log.Info("Listing all tenant authorizations successful")
+	return tenantAuths, nil
 }

--- a/auth/policy.go
+++ b/auth/policy.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	log "github.com/Sirupsen/logrus"
+	jwt "github.com/dgrijalva/jwt-go"
+
+	ccnerrors "github.com/contiv/ccn_proxy/common/errors"
+	"github.com/contiv/ccn_proxy/common/types"
+)
+
+//
+// checkRolePolicy checks the authorization token for a role claim that matches
+// the specified role. The policy matches if role to check for is contained in
+// role present in the token.
+//
+// Parameters:
+//  (Receiver): authorization token object
+//  desired: desired role for which to search a claim
+//
+// Return values:
+//  error: nil if policy check is successful, types.InternalError if claim
+//  statement is malformed, types.UnauthorizedError if unauthorized by policy.
+//
+func (authZ *Token) checkRolePolicy(desired types.RoleType) error {
+
+	// convert desired role name to a claim string
+	claimStr, err := GenerateClaimKey(desired)
+	if err != nil {
+		msg := "malformed claim statement, error:" + err.Error()
+		log.Error(msg)
+		return ccnerrors.NewError(ccnerrors.Internal, msg)
+	}
+
+	claims := authZ.tkn.Claims.(jwt.MapClaims)
+	v, ok := claims[claimStr]
+	if ok {
+		granted, err := types.Role(v.(string))
+		if err == nil {
+			return checkAccessClaim(granted, desired)
+		}
+	}
+
+	log.Debug("access denied for claim:", claimStr)
+	return ccnerrors.ErrUnauthorized
+}
+
+//
+// checkTenantPolicy checks the authorization token for an explicit claim that
+// allows access to a tenant
+// TODO  add wildcard access to all tenants.
+//
+// Parameters:
+//  (Receiver): authorization token object
+//  tenant: tenant object for which to check policy
+//  desiredAccess: a role/capability that specifies desired level of access.
+//
+// Return values:
+//  error: nil if policy check is successful, types.InternalError if claim
+//  statements are malformed, types.UnauthorizedError if unauthorized by policy.
+//
+func (authZ *Token) checkTenantPolicy(tenant types.Tenant, desiredAccess interface{}) error {
+
+	// convert the tenant object to a claim string
+	claimStr, err := GenerateClaimKey(tenant)
+	if err != nil {
+		msg := "malformed claim statement, error:" + err.Error()
+		log.Error(msg)
+		return ccnerrors.NewError(ccnerrors.Internal, msg)
+	}
+
+	// check for explicit authorization to the tenant
+	claims := authZ.tkn.Claims.(jwt.MapClaims)
+	if v, ok := claims[claimStr]; ok {
+
+		// If this claim is present, value is the role assigned with
+		// the tenant.
+		role, err := types.Role(v.(string))
+		if err != nil {
+			msg := "malformed claim statement, error:" + err.Error()
+			log.Error(msg)
+			return ccnerrors.NewError(ccnerrors.Internal, msg)
+		}
+
+		if checkAccessClaim(role, desiredAccess) == nil {
+			// Success
+			return nil
+		}
+		log.Debug("access denied for claim:", claimStr, " with role:", role.String())
+	}
+
+	// @TODO: Add wildcard claims
+	/*
+		// If we are here, then an explicit claim check didn't succeed. Look
+		// for a wildcard claim.
+		claimStr, err = GenerateClaimKey(types.ALL_CLUSTERS_AUTH)
+		if err != nil {
+			msg := "malformed claim statement, error:" + err.Error()
+			log.Error(msg)
+			return types.NewError(types.Internal, msg)
+		}
+
+		if v, ok := authZ.t.Claims[claimStr]; ok && v.(bool) == true {
+			return nil
+		}
+	*/
+
+	log.Debug("access denied for claim:", claimStr)
+	return ccnerrors.ErrUnauthorized
+}

--- a/common/errors/errors.go
+++ b/common/errors/errors.go
@@ -41,9 +41,19 @@ const (
 	KeyNotFound
 	CommonStateFieldsMissing
 	InvalidCall
+	ReadingFromStore
 
+	Unauthorized
+	IllegalArguments
+	UnsupportedType
+	ParsingToken
+	Internal
+	ParsingRequest
+	UnmarshalingBody
+	UpdateAuthorization
+	PartialFailureToAddAuthz
+	PartialFailureToUpdateAuthz
 	StateDriverNotCreated
-
 	KeyExists
 	IllegalOperation
 	AccessDenied
@@ -83,6 +93,42 @@ var ErrIllegalOperation = NewError(IllegalOperation, "illegal operation")
 
 // ErrAccessDenied is used when the user access is denied
 var ErrAccessDenied = NewError(AccessDenied, "Access Denied")
+
+// ErrReadingFromStore indicates an error condition while reading from the KV store
+var ErrReadingFromStore = NewError(ReadingFromStore, "error reading from KV store")
+
+// ErrUnauthorized indicates that an authorization doesn't have a claim
+var ErrUnauthorized = NewError(Unauthorized, "unauthorized access")
+
+// ErrIllegalArguments indicates that illegal arguments were received for
+// an API call
+var ErrIllegalArguments = NewError(IllegalArguments, "illegal arguments")
+
+// ErrUnsupportedType indicates that an unsupported object type was used
+// in a function or method call, e.g. checkAccessClaim
+var ErrUnsupportedType = NewError(UnsupportedType, "Unsupported object type")
+
+// ErrParsingToken indicates an error when trying to parse
+// an authorization token
+var ErrParsingToken = NewError(ParsingToken, "failed to parse authz token")
+
+// ErrInternal is returned from functions where internal logic runs into inconsistency issues.
+var ErrInternal = NewError(Internal, "an internal error has occurred")
+
+// ErrParsingRequest indicates an error parsing the incoming HTTP request
+var ErrParsingRequest = NewError(ParsingRequest, "failed to parse HTTP request body")
+
+// ErrUnmarshalingBody indicates an error unmarshalling request body
+var ErrUnmarshalingBody = NewError(UnmarshalingBody, "failed to unmarshall request body")
+
+// ErrUpdateAuthorization indicates an error when updating an authorization
+var ErrUpdateAuthorization = NewError(UpdateAuthorization, "failed to update authorization")
+
+// ErrPartialFailureToAddAuthz indicates an error when a new authorizatin is being added to CCN
+var ErrPartialFailureToAddAuthz = NewError(PartialFailureToAddAuthz, "failed to add authorization")
+
+// ErrPartialFailureToUpdateAuthz indicates an error when an authorization is being update
+var ErrPartialFailureToUpdateAuthz = NewError(PartialFailureToUpdateAuthz, "failed to update authorization")
 
 //
 // CCNError describes an error response message used by CCN APIs

--- a/common/test/utils.go
+++ b/common/test/utils.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+
 	"github.com/contiv/ccn_proxy/common"
+	"github.com/contiv/ccn_proxy/state"
 )
 
 // GetDatastore returns the value of `os.Getenv("USE_DATASTORE")` or `etcd` by default
@@ -16,7 +18,7 @@ func GetDatastore() string {
 		return datastore
 	}
 
-	return common.EtcdName
+	return state.EtcdName
 }
 
 // GetDatastoreAddress returns the data store address; mainly used for testing.
@@ -30,9 +32,9 @@ func GetDatastoreAddress() string {
 	}
 
 	switch GetDatastore() {
-	case common.EtcdName:
+	case state.EtcdName:
 		return "etcd://127.0.0.1:2379"
-	case common.ConsulName:
+	case state.ConsulName:
 		return "consul://127.0.0.1:8500"
 	default:
 		return ""
@@ -48,7 +50,7 @@ func CleanupDatastore(dsName string, paths []string) {
 	log.Info("Cleaning data store...")
 
 	switch dsName {
-	case common.EtcdName:
+	case state.EtcdName:
 		for _, path := range paths {
 			log.Infof("Cleaning %q", path)
 
@@ -65,7 +67,7 @@ func CleanupDatastore(dsName string, paths []string) {
 				}
 			}
 		}
-	case common.ConsulName:
+	case state.ConsulName:
 		for _, path := range paths {
 			log.Infof("Cleaning %q", path)
 

--- a/common/types/authz.go
+++ b/common/types/authz.go
@@ -1,0 +1,226 @@
+package types
+
+import (
+	"encoding/json"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/contiv/ccn_proxy/common"
+)
+
+// Consts that will be used across different packages
+const (
+
+	// CCNProxyDir is the directory in the KV store
+	// where directories and keys used by
+	// CCN proxy will be stored
+	CCNProxyDir = "ccn_proxy"
+
+	// AuthZDir is the directory under which all
+	// types.Authorizations state will be saved
+	// in the KV store
+	AuthZDir = CCNProxyDir + "/" + "authorizations"
+)
+
+//
+// Authorization represents the dynamic policy that defines mapping of
+// principals and their access claims to entities with certain capabilities.
+//
+// Principals are also called subjects. Entities are also called
+// objects. Objects and the capabilities defined on them are termed as
+// a claim's key and value.
+//
+//
+//                              Capabilities
+//                             (claim's value)
+//        Principals    ------------------------->  Entities
+//        (subjects)                              (objects or the claim's key)
+//
+//
+// This is a many-to-many association - one principal will have access to many
+// claims (e.g., for different tenants), and one claim (e.g., for a specific
+// tenant) might be associated with many principals.
+//
+// All subject-object mappings must be unique - hence the primary key is a
+// combination of the principal and claims' keys.
+//
+// Fields:
+//  CommonState: Embedded common state struct (which will be part of all structs that implement
+//               types.State)
+//  UUID: unique ID for an authorization.
+//  PrincipalID: UUID of the subject.
+//  ClaimKey: string encoding of the claim's key associated with the authorization
+//  ClaimValue: string encoding of the claim's value associated with the
+//    authorization
+//
+type Authorization struct {
+	CommonState
+	UUID        string `json:"uuid"`
+	PrincipalID string `json:"principalID"`
+	ClaimKey    string `json:"claimKey"`
+	ClaimValue  string `json:"claimValue"`
+}
+
+//
+// "Schema" of how authorizations will be stored in the KV store
+//
+//
+//  /[AuthZDir]/{AuthZID:[AuthZState]}
+//
+//       Key: Authorization UUID or AuthZID
+//       Value: Authorization instance
+//
+//  e.g.
+//  /ccnproxy/authorizations/{11111111: {
+// 	                                   CommonState
+//                                         UUID: "11111111"
+//                                         Principal:
+//                                         PrincipalID: "12345678"
+//                                         ClaimKey: "tenant:t1"
+//                                         ClaimValue: "devops"
+//                                      }
+//                            }
+//
+//  /ccnproxy/authorizations/{22222222: {
+// 	                                   CommonState
+//                                         UUID: "22222222"
+//                                         Principal:
+//                                         PrincipalID: "12345678"
+//                                         ClaimKey: "tenant:t2"
+//                                         ClaimValue: "devops"
+//                                      }
+//                            }
+//
+// For each authz instance, the claim key indicates the tenants (or
+// other objects) that the authorization allows access to. The claim
+// value indicates the type of capability or access that is allowed
+// on the object in the claim-key. This capability can also be specified
+// as a "role".
+//
+
+//
+// Write adds an authz instance to the authz dir in the KV store
+//
+// Parameters:
+//  (Receiver): authorization object on which operation is occurring
+//
+// Return Values:
+//  error: Error received from StateDriver
+//         nil if operation is successful
+//
+func (a *Authorization) Write() error {
+
+	defer common.Untrace(common.Trace())
+
+	// write the authz state
+	key := AuthZDir + "/" + a.UUID
+	return a.StateDriver.WriteState(key, a, json.Marshal)
+}
+
+//
+// Clear removes an authz instance from the authz dir in the KV store
+//
+// Parameters:
+//  (Receiver): authorization object on which operation is occurring
+//  ID: of the authorization object
+//
+// Return Values:
+//  error: Any error from the state driver
+//         Nil if successful
+//
+func (a *Authorization) Clear() error {
+
+	defer common.Untrace(common.Trace())
+	log.Debug("deleting authorization:", a.UUID)
+	key := AuthZDir + "/" + a.UUID
+	return a.StateDriver.ClearState(key)
+}
+
+//
+// Read looks up an authorization entry in the authz dir
+//
+// Parameters:
+//  (Receiver): authorization object on which operation is occurring
+//  UUID: of the authZ that needs to be read
+//
+// Return Values:
+//  error: Any error from the state driver
+//         Nil if successful
+//
+func (a *Authorization) Read(UUID string) error {
+
+	defer common.Untrace(common.Trace())
+	key := AuthZDir + "/" + UUID
+	return a.StateDriver.ReadState(key, a, json.Unmarshal)
+}
+
+//
+// ReadAll returns all authorizations in the authz dir
+//
+// Return Values:
+//  []State: List of authorization states
+//  error: Any error when reading from the KV store
+//         nil if operation is successful
+//
+func (a *Authorization) ReadAll() ([]State, error) {
+
+	defer common.Untrace(common.Trace())
+	key := AuthZDir
+	return a.StateDriver.ReadAllState(key, a, json.Unmarshal)
+}
+
+/*
+//
+// CapabilityType represents a capability that captures an operation
+// specific authorization. These capabilities are associated with roles
+// that are assigned to security principals.  Capabiliites themselves
+// are not stored in an authorized token, but are derived from the role.
+// A capability check is carried out by APIs to see if caller principal
+// has a role that grants this capability.
+//
+type CapabilityType int
+
+// TODO: Make these bitmasks
+const (
+
+	// Tenant specific capabilities
+	capCreateTenant = iota
+	capCreateTenant
+	capUpdateTenant
+	capDeleteTenant
+
+	// Network specific capabilties
+	capCreateNetwork
+	capReadNetwork
+	capUpdateNetwork
+	capDeleteTenant
+
+	// Define all capabilities before this
+	capLast
+)
+
+func (typ CapabilityType) String() string {
+	s := ""
+	switch typ {
+	case capCreateTenant:
+		s += "capCreateTenant"
+	case capReadTenant:
+		s += "capReadTenant"
+	case capUpdateTenant:
+		s += "capUpdateTenant"
+	case capDeleteTenant:
+		s += "capDeleteTenant"
+
+	case capCreateNetwork:
+		s += "capCreateNetwork"
+	case capReadNetwork:
+		s += "capReadNetwork"
+	case capUpdateNetwork:
+		s += "capUpdateNetwork"
+	case capDeleteNetwork:
+		s += "capDeleteNetwork"
+	}
+
+	return s
+}
+*/

--- a/common/types/state.go
+++ b/common/types/state.go
@@ -30,6 +30,7 @@ type StateDriver interface {
 	Read(key string) ([]byte, error)
 	ReadAll(baseKey string) ([][]byte, error)
 	Write(key string, value []byte) error
+	Clear(key string) error
 	WatchAll(baseKey string, chValueChanges chan [2][]byte) error
 
 	ReadState(key string, value State,

--- a/common/types/test/authz_test.go
+++ b/common/types/test/authz_test.go
@@ -1,0 +1,142 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/contiv/ccn_proxy/common/types"
+	"github.com/contiv/ccn_proxy/state"
+	. "gopkg.in/check.v1"
+)
+
+var (
+	config      types.KVStoreConfig
+	stateDriver types.StateDriver
+	commonState types.CommonState
+	a1, a2      types.Authorization
+)
+
+func Test(t *testing.T) {
+	// create config for KV store
+	config = types.KVStoreConfig{
+		StoreURL: "etcd://127.0.0.1:2379",
+	}
+
+	// create a state driver
+	var err error
+	stateDriver, err = state.NewStateDriver(state.EtcdName, &config)
+	if err != nil {
+		t.Fatal("failed to create a new state driver, err:", err)
+	}
+
+	// create common state
+	commonState = types.CommonState{
+		ID:          "0000",
+		StateDriver: stateDriver,
+	}
+
+	// create two authorizations
+	a1 = types.Authorization{
+		CommonState: commonState,
+		UUID:        "1111",
+		PrincipalID: "2222",
+		ClaimKey:    "tenant: Tenant1",
+		ClaimValue:  "devops",
+	}
+
+	a2 = types.Authorization{
+		CommonState: commonState,
+		UUID:        "3333",
+		PrincipalID: "4444",
+		ClaimKey:    "tenant: Tenant2",
+		ClaimValue:  "devops",
+	}
+
+	TestingT(t)
+}
+
+// TestAuthZWrite tests writing an authz
+func TestAuthZWrite(t *testing.T) {
+
+	// write authorization
+	a1.Write()
+
+	// read authorization
+	readAuthz := &types.Authorization{}
+	readAuthz.StateDriver = stateDriver
+	(*readAuthz).Read(a1.UUID)
+
+	// check if the read authz matches the one written
+	if *readAuthz != a1 {
+		t.Fatal("Authorization value read doesn't match ",
+			"written value, Read:", readAuthz, "Written:", a1)
+	}
+}
+
+// TestAuthZClear tests deleting an authz
+func TestAuthZClear(t *testing.T) {
+
+	// write an authz
+	a1.Write()
+
+	// read the written authz
+	readAuthz := &types.Authorization{}
+	readAuthz.StateDriver = stateDriver
+	(*readAuthz).Read(a1.UUID)
+
+	// check if the read authz matches the one written
+	if *readAuthz != a1 {
+		t.Fatal("Authorization value read doesn't match ",
+			"written value, Read:", readAuthz, "Written:", a1)
+	}
+
+	// clear the written authz
+	a1.Clear()
+
+	// try to read the cleared authz
+	readAuthz2 := &types.Authorization{}
+	readAuthz2.StateDriver = stateDriver
+	(*readAuthz2).Read(a1.UUID)
+
+	// expecting read to fail
+	if *readAuthz2 == a1 {
+		t.Fatal("Authz value read matches written value, ",
+			"expecting read to fail after clear")
+	}
+
+}
+
+// TestAuthZReadAll tests reading all authorizations in the KV store
+func TestAuthZReadAll(t *testing.T) {
+
+	// write 2 authorizations
+	a1.Write()
+	a2.Write()
+
+	// read all authorizations
+	readAuthz := &types.Authorization{}
+	readAuthz.StateDriver = stateDriver
+	aList, err := (*readAuthz).ReadAll()
+	if err != nil {
+		t.Fatal("ReadAll operation failed, err:", err)
+	}
+
+	tmp1, ok := aList[0].(*types.Authorization)
+	if !ok {
+		t.Fatal("failed to convert state to Authorization")
+	}
+
+	tmp2, ok := aList[1].(*types.Authorization)
+	if !ok {
+		t.Fatal("failed to convert state to Authorization")
+	}
+
+	// check if any of the read values match 1st written value
+	if !(*tmp1 == a1 || *tmp2 == a1) {
+		t.Fatal("Neither read values:", *tmp1, " match written value:", a1)
+	}
+	// check if any of the read values match 2nd written value
+	if !(*tmp1 == a2 || *tmp2 == a2) {
+		t.Fatal("Neither read values:", *tmp2, " match written value:", a2)
+	}
+
+}

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -5,6 +5,14 @@ import (
 	"github.com/contiv/ccn_proxy/common/errors"
 )
 
+// DerivedFromPrincipalRole is a constant that is used to indicate
+// that the capability or access level (i.e. ClaimValue) to an
+// object (specified in ClaimKey, e.g: "tenant: TenantA") is based
+// on the principal's role. A principal's role is defined in
+// each Principal's object:
+//          e.g. Principal {UUID: "xxxx", Role: "admin|ops"}
+const DerivedFromPrincipalRole string = "DerivedFromPrincipalRole"
+
 // ADConfiguration entry
 //
 // Fields:
@@ -39,6 +47,10 @@ const (
 	Invalid                 // Invalid role, this needs to be the last role
 )
 
+// Tenant is a type to represent the name of the tenant in CCN
+type Tenant string
+
+//
 // Principal represents a 'user' to 'role' association. A 'user' can have many
 // 'roles', and thus can have multiple principals representing it during a
 // 'session'. This set is also known as the active role set (ARS).

--- a/common/utils.go
+++ b/common/utils.go
@@ -2,7 +2,10 @@ package common
 
 import (
 	"net/http"
+	"runtime"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // IsEmpty checks if the given string is empty or not
@@ -12,6 +15,48 @@ import (
 //  true if the string is empty otherwise false
 func IsEmpty(str string) bool {
 	return len(strings.TrimSpace(str)) == 0
+}
+
+var doTracing = false
+
+//
+// Trace emits a debug level log message with info of the caller function.
+//
+// Returns:
+//	name of caller function if no error, "" otherwise.
+//
+func Trace() string {
+	if !doTracing {
+		return ""
+	}
+
+	pc, _, _, ok := runtime.Caller(1)
+	if ok {
+		f := runtime.FuncForPC(pc)
+		log.Debug("Entering: ", f.Name())
+		return f.Name()
+	}
+
+	return ""
+}
+
+//
+// Untrace should be used with Trace function as defer Untrace(Trace()).
+//
+// Parameters:
+//	s: name of function being traced. This is the output from Trace
+//	function.
+//
+// Returns nothing
+//
+func Untrace(s string) {
+	if !doTracing {
+		return
+	}
+
+	// By taking in the parameter as a result of Trace, we avoid calling in
+	// runtime twice.
+	log.Debug("Leaving: ", s)
 }
 
 // SetJSONContentType sets the Content-Type header to JSON.

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/contiv/ccn_proxy/common"
 	"github.com/contiv/ccn_proxy/proxy"
+	"github.com/contiv/ccn_proxy/state"
 	"github.com/contiv/ccn_proxy/usermgmt"
 
 	log "github.com/Sirupsen/logrus"
@@ -94,6 +94,29 @@ func processFlags() {
 	flag.Parse()
 }
 
+/*
+// initializeStateDriver initializes the state driver based on the given data store address
+// params:
+//  dataStoreAddress: address of the data store
+// return values:
+//  returns any error as NewStateDriver() + validation errors
+func initializeStateDriver(dataStoreAddress string) error {
+	if common.IsEmpty(dataStoreAddress) {
+		return errors.New("Empty data store address")
+	}
+
+	if strings.HasPrefix(dataStoreAddress, state.EtcdName+"://") {
+		_, err := state.NewStateDriver(state.EtcdName, &types.KVStoreConfig{StoreURL: dataStoreAddress})
+		return err
+	} else if strings.HasPrefix(dataStoreAddress, state.ConsulName+"://") {
+		_, err := state.NewStateDriver(state.ConsulName, &types.KVStoreConfig{StoreURL: dataStoreAddress})
+		return err
+	}
+
+	return errors.New("Invalid data store address")
+}
+*/
+
 func main() {
 
 	log.Println(ProgramName, ProgramVersion, "starting up...")
@@ -105,7 +128,7 @@ func main() {
 	}
 
 	// Initialize data store
-	if err := common.InitializeStateDriver(dataStoreAddress); err != nil {
+	if err := state.InitializeStateDriver(dataStoreAddress); err != nil {
 		log.Fatalln(err)
 		return
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -9,8 +9,10 @@ import (
 	"net/url"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/ccn_proxy/auth"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/contiv/ccn_proxy/common/types"
 	"github.com/gorilla/mux"
 )
 
@@ -181,6 +183,10 @@ func addRoutes(s *Server, router *mux.Router) {
 	//
 	addUserMgmtRoutes(router)
 
+	// Authorization endpoints
+	//
+	addAuthorizationRoutes(router)
+
 	//
 	// RBAC-enforced endpoints with optional filtering of results
 	//
@@ -229,4 +235,13 @@ func addUserMgmtRoutes(router *mux.Router) {
 	router.Path("/api/v1/ccn_proxy/local_users/{username}").Methods("PATCH").HandlerFunc(updateLocalUser)
 	router.Path("/api/v1/ccn_proxy/local_users/{username}").Methods("GET").HandlerFunc(getLocalUser)
 	router.Path("/api/v1/ccn_proxy/local_users").Methods("GET").HandlerFunc(getLocalUsers)
+}
+
+// addAuthorizationRoutes adds authorization routes
+func addAuthorizationRoutes(router *mux.Router) {
+	router.Path("/api/v1/ccn_proxy/authorizations").Methods("POST").HandlerFunc(addTenantAuthorization)
+	router.Path("/api/v1/ccn_proxy/authorizations/{authzUUID}").Methods("DELETE").HandlerFunc(deleteTenantAuthorization)
+	router.Path("/api/v1/ccn_proxy/authorizations/{authzUUID}").Methods("GET").HandlerFunc(getTenantAuthorization)
+	router.Path("/api/v1/ccn_proxy/authorizations/{authzUUID}").Methods("PATCH").HandlerFunc(updateTenantAuthorization)
+	router.Path("/api/v1/ccn_proxy/authorizations").Methods("GET").HandlerFunc(listTenantAuthorizations)
 }

--- a/proxy/struct.go
+++ b/proxy/struct.go
@@ -21,6 +21,52 @@ type localUserCreateRequest struct {
 	Role     string `json:"role"`
 }
 
+//
+// AddTenantAuthorizationRequest message is sent for AddTenantAuthorization
+// operation.
+//
+// Fields:
+//  PrincipalName: name of the user for whom an authorization needs to be added. This
+//    can be a local user or an LDAP group
+//  TenantName: Tenant name that the above user will have access to
+//  Local: true if the name corresponds to a local user, false if it's an LDAP
+//    group.
+//
+type AddTenantAuthorizationRequest struct {
+	PrincipalName string
+	TenantName    string
+	Local         bool
+}
+
+//
+// GetAuthorizationReply structure is used for Get*Authorization
+// operation.
+//
+// Fields:
+//  PrincipalID: UUID of the subject.
+//  ClaimKey: string encoding of the claim's key associated with the authorization
+//  ClaimValue: string encoding of the claim's value associated with the
+//    authorization
+//
+type GetAuthorizationReply struct {
+	AuthzUUID   string
+	PrincipalID string
+	ClaimKey    string
+	ClaimValue  string
+}
+
+//
+// ListAuthorizationsReply message is received from List*Authorizations
+// operation.
+//
+// Fields:
+//  AuthList: slice of GetAuthorizationReply structures
+//  Error: error encountered during operation, if any
+//
+type ListAuthorizationsReply struct {
+	AuthList []GetAuthorizationReply
+}
+
 // errorResponse represent error response; used to write error messages to http response.
 type errorResponse struct {
 	Error string `json:"error"`

--- a/state/authz.go
+++ b/state/authz.go
@@ -1,0 +1,318 @@
+package state
+
+import (
+	"encoding/json"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/contiv/ccn_proxy/common"
+	ccnerrors "github.com/contiv/ccn_proxy/common/errors"
+	"github.com/contiv/ccn_proxy/common/types"
+)
+
+//
+// InsertAuthorization is a convenience function to add a new entry
+// to the authz dir
+//
+func InsertAuthorization(a *types.Authorization) error {
+	defer common.Untrace(common.Trace())
+	log.Debug("creating authorization:", a)
+	return a.Write()
+}
+
+//
+// GetAuthorization is a convenience function to look up an
+// authorization entry by its UUID.
+//
+func GetAuthorization(UUID string) (types.Authorization, error) {
+	defer common.Untrace(common.Trace())
+
+	a := types.Authorization{}
+	sd, err := GetStateDriver()
+	if err != nil {
+		return a, err
+	}
+
+	a.StateDriver = sd
+	err = a.Read(UUID)
+	return a, err
+}
+
+//
+// DeleteAuthorization is a convenience function to remove
+// an authz from the authz dir
+//
+func DeleteAuthorization(ID string) error {
+	defer common.Untrace(common.Trace())
+
+	log.Debug("deleting authorization:", ID)
+
+	a := types.Authorization{}
+	a.UUID = ID
+	sd, err := GetStateDriver()
+	if err != nil {
+		return err
+	}
+	a.StateDriver = sd
+	return a.Clear()
+}
+
+//
+// ListAuthorizations looks up all authorizations in
+// authz dir
+//
+// Return Values:
+//  []types.Authorization: slice containing authorization instances
+//  error: Error when reading from KV store
+//         nil if operation is successful
+//
+func ListAuthorizations() (
+	[]types.Authorization, error) {
+	defer common.Untrace(common.Trace())
+
+	a := &types.Authorization{}
+	sd, err := GetStateDriver()
+	if err != nil {
+		return nil, err
+	}
+	(*a).StateDriver = sd
+
+	allAuthZList, err := a.StateDriver.ReadAllState(types.AuthZDir, a, json.Unmarshal)
+	if err != nil {
+		log.Error("failed to ReadAllState, err:", err)
+		return nil, ccnerrors.ErrReadingFromStore
+	}
+
+	var list []types.Authorization
+	for _, auth := range allAuthZList {
+		tmp, ok := auth.(*types.Authorization)
+		if ok {
+			list = append(list, *tmp)
+		}
+	}
+
+	return list, nil
+}
+
+//
+// ListAuthorizationsByPrincipal looks up all authorizations in
+// authz dir for the specific principal (subject).
+//
+// Parameters:
+//  ID: of the principal for whom authorizations need to be returned
+//
+// Return Values:
+//  []types.Authorization: slice containing authorization instances
+//  error: Error when reading from KV store
+//         nil if operation is successful
+//
+//func (a *Authorization) ListAuthorizationsByPrincipal(ID string) (
+func ListAuthorizationsByPrincipal(ID string) (
+	[]types.Authorization, error) {
+	defer common.Untrace(common.Trace())
+
+	a := &types.Authorization{}
+	sd, err := GetStateDriver()
+	if err != nil {
+		return nil, err
+	}
+	(*a).StateDriver = sd
+
+	allAuthZList, err := a.StateDriver.ReadAllState(types.AuthZDir, a, json.Unmarshal)
+	if err != nil {
+		log.Error("failed to ReadAllState, err:", err)
+		return nil, ccnerrors.ErrReadingFromStore
+	}
+
+	var match []types.Authorization
+	for _, auth := range allAuthZList {
+		tmp, ok := auth.(*types.Authorization)
+		if ok {
+			if tmp.PrincipalID == ID {
+				match = append(match, *tmp)
+
+			}
+		}
+	}
+
+	return match, nil
+}
+
+//
+// DeleteAuthorizationsByPrincipal deletes all authorizations in
+// in the KV store for the specific principal (subject).
+//
+// Parameters:
+//  ID: of the principal whose authorizations need to be removed
+//
+// Return Values:
+//  error: Any errors encountered when reading or deleting
+//         from the KV store
+//
+func DeleteAuthorizationsByPrincipal(principalID string) error {
+	defer common.Untrace(common.Trace())
+
+	a := &types.Authorization{}
+	sd, err := GetStateDriver()
+	if err != nil {
+		return err
+	}
+	(*a).StateDriver = sd
+
+	allAuthZList, err := a.StateDriver.ReadAllState(types.AuthZDir, a, json.Unmarshal)
+	if err != nil {
+		log.Error("failed to ReadAllState, err:", err)
+		return ccnerrors.ErrReadingFromStore
+	}
+
+	for _, auth := range allAuthZList {
+		tmp, ok := auth.(*types.Authorization)
+		if ok {
+			if tmp.PrincipalID == principalID {
+
+				// record UUID so that its key path
+				// can be determined
+				a.UUID = tmp.UUID
+				err = a.Clear()
+				if err != nil {
+					log.Error("failed to delete authorization, err:", err)
+					return err
+				}
+			}
+		}
+	}
+
+	return err
+}
+
+//
+// ListAuthorizationsByClaim looks up all authorizations in the
+// authz dir that contains a claim key
+//
+// Parameters:
+//  claim: claim string (object) for which authorizations are being searched.
+//
+// Return Values:
+//  []types.Authorization: slice containing authorizations
+//  error: Any error encountered when reading from the KV store
+//         nil if operation is successful
+//
+func ListAuthorizationsByClaim(claim string) (
+	[]types.Authorization, error) {
+
+	defer common.Untrace(common.Trace())
+
+	a := &types.Authorization{}
+	sd, err := GetStateDriver()
+	if err != nil {
+		return nil, err
+	}
+	(*a).StateDriver = sd
+
+	allAuthZList, err := a.StateDriver.ReadAllState(types.AuthZDir, a, json.Unmarshal)
+	if err != nil {
+		log.Error("failed to ReadAllState, err:", err)
+		return nil, ccnerrors.ErrReadingFromStore
+	}
+
+	var match []types.Authorization
+	for _, auth := range allAuthZList {
+		tmp, ok := auth.(*types.Authorization)
+		if ok {
+			if tmp.ClaimKey == claim {
+				match = append(match, *tmp)
+			}
+		}
+	}
+	return match, nil
+}
+
+//
+// DeleteAuthorizationsByClaim deletes all authorizations in the
+// authz dir in the KV store that contain the chosen claim
+//
+// Parameters:
+//  claim: claim string (object) for which authorizations are being searched.
+//
+// Return Values:
+//  error: Errors encountered when reading and deleting from the authz dir
+//         nil if operation is successful
+//
+func DeleteAuthorizationsByClaim(claim string) error {
+
+	defer common.Untrace(common.Trace())
+
+	a := &types.Authorization{}
+	sd, err := GetStateDriver()
+	if err != nil {
+		return err
+	}
+	(*a).StateDriver = sd
+
+	allAuthZList, err := a.StateDriver.ReadAllState(types.AuthZDir, a, json.Unmarshal)
+	if err != nil {
+		log.Error("failed to ReadAllState, err:", err)
+		return ccnerrors.ErrReadingFromStore
+	}
+
+	for _, auth := range allAuthZList {
+		tmp, ok := auth.(*types.Authorization)
+		if ok {
+			if tmp.ClaimKey == claim {
+				// record UUID so that its key path
+				// can be determined
+				a.UUID = tmp.UUID
+				err = a.Clear()
+				if err != nil {
+					log.Error("failed to delete authorization, err:", err)
+					return err
+				}
+			}
+		}
+	}
+	return err
+}
+
+//
+// ListAuthorizationsByClaimAndPrincipal looks up all authorizations in
+// the KV store for a specific claim and principal
+//
+// Parameters:
+//  claim: claim string for which authorizations are being searched.
+//  ID: of the principal for whom authorizations need to be returned
+//
+// Return Values:
+//  []types.Authorization: slice containing authorizations.
+//  error: Any error encountered when reading from the KV store
+//         nil if operation is successful
+//
+func ListAuthorizationsByClaimAndPrincipal(claim string, ID string) (
+	[]types.Authorization, error) {
+
+	defer common.Untrace(common.Trace())
+
+	a := &types.Authorization{}
+	sd, err := GetStateDriver()
+	if err != nil {
+		return nil, err
+	}
+	(*a).StateDriver = sd
+
+	allAuthZList, err := a.StateDriver.ReadAllState(types.AuthZDir, a, json.Unmarshal)
+	if err != nil {
+		log.Error("failed to ReadAllState, err:", err)
+		return nil, ccnerrors.ErrReadingFromStore
+	}
+
+	var match []types.Authorization
+	for _, auth := range allAuthZList {
+		tmp, ok := auth.(*types.Authorization)
+		if ok {
+			if (tmp.ClaimKey == claim) && (tmp.PrincipalID == ID) {
+				match = append(match, *tmp)
+			}
+		}
+	}
+
+	return match, nil
+}

--- a/state/consulstatedriver.go
+++ b/state/consulstatedriver.go
@@ -317,6 +317,21 @@ func (d *ConsulStateDriver) WatchAll(baseKey string, chValueChanges chan [2][]by
 }
 
 //
+// Clear clears the value for a key in consul
+//
+// Parameters:
+//   key: key for which value is to be cleared
+//
+// Return value:
+//   error: Error returned by consul client when deleting a key
+//
+func (d *ConsulStateDriver) Clear(key string) error {
+	key = processKey(key)
+	_, err := d.Client.KV().Delete(key, nil)
+	return err
+}
+
+//
 // ClearState clears the state for a key in consul
 //
 // Parameters:
@@ -326,9 +341,7 @@ func (d *ConsulStateDriver) WatchAll(baseKey string, chValueChanges chan [2][]by
 //   error: Error returned by consul client when deleting a key
 //
 func (d *ConsulStateDriver) ClearState(key string) error {
-	key = processKey(key)
-	_, err := d.Client.KV().Delete(key, nil)
-	return err
+	return d.Clear(key)
 }
 
 //

--- a/state/driverfactory.go
+++ b/state/driverfactory.go
@@ -1,4 +1,4 @@
-package common
+package state
 
 import (
 	"errors"
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/contiv/ccn_proxy/common"
 	ccnerrors "github.com/contiv/ccn_proxy/common/errors"
 	"github.com/contiv/ccn_proxy/common/types"
-	"github.com/contiv/ccn_proxy/state"
 )
 
 // struct that holds the driver type
@@ -19,10 +19,10 @@ type driver struct {
 // stateDriverRegistry is a registry that contains all the state driver details
 var stateDriverRegistry = map[string]driver{
 	EtcdName: {
-		Type: reflect.TypeOf(state.EtcdStateDriver{}),
+		Type: reflect.TypeOf(EtcdStateDriver{}),
 	},
 	ConsulName: {
-		Type: reflect.TypeOf(state.ConsulStateDriver{}),
+		Type: reflect.TypeOf(ConsulStateDriver{}),
 	},
 }
 
@@ -61,7 +61,7 @@ func initHelper(driverRegistry map[string]driver, driverName string) (interface{
 // return values:
 //  returns types.StateDriver on successful instantiation or any relevant error
 func NewStateDriver(name string, config *types.KVStoreConfig) (types.StateDriver, error) {
-	if IsEmpty(name) || nil == config {
+	if common.IsEmpty(name) || nil == config {
 		return nil, errors.New("Empty driver name or configuration")
 	}
 
@@ -100,7 +100,7 @@ func GetStateDriver() (types.StateDriver, error) {
 // return values:
 //  returns any error as NewStateDriver() + validation errors
 func InitializeStateDriver(dataStoreAddress string) error {
-	if IsEmpty(dataStoreAddress) {
+	if common.IsEmpty(dataStoreAddress) {
 		return errors.New("Empty data store address, please set --data-store-address")
 	}
 

--- a/state/etcdstatedriver.go
+++ b/state/etcdstatedriver.go
@@ -249,20 +249,33 @@ func (d *EtcdStateDriver) WatchAll(baseKey string, chValueChanges chan [2][]byte
 }
 
 //
-// ClearState removes a key from etcd
+// Clear removes a key from etcd
 //
 // Parameters:
-//   key: key to be stored
+//   key: key to be removed
 //
 // Return value:
 //   error: Error returned by etcd client when deleting a key
 //
-func (d *EtcdStateDriver) ClearState(key string) error {
+func (d *EtcdStateDriver) Clear(key string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
 	_, err := d.KeysAPI.Delete(ctx, key, nil)
 	return err
+}
+
+//
+// ClearState removes a key from etcd
+//
+// Parameters:
+//   key: key to be removed
+//
+// Return value:
+//   error: Error returned by etcd client when deleting a key
+//
+func (d *EtcdStateDriver) ClearState(key string) error {
+	return d.Clear(key)
 }
 
 //

--- a/state/test/authz_test.go
+++ b/state/test/authz_test.go
@@ -1,0 +1,236 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/contiv/ccn_proxy/common/test"
+	"github.com/contiv/ccn_proxy/common/types"
+	"github.com/contiv/ccn_proxy/state"
+	. "gopkg.in/check.v1"
+)
+
+var (
+	config      types.KVStoreConfig
+	stateDriver types.StateDriver
+	commonState types.CommonState
+	a1, a2      types.Authorization
+)
+
+func Test(t *testing.T) {
+	// create config for KV store
+	config = types.KVStoreConfig{
+		//StoreURL: "etcd://127.0.0.1:2379",
+		StoreURL: test.GetDatastoreAddress(),
+	}
+
+	// create a state driver
+	var err error
+	stateDriver, err = state.NewStateDriver(state.EtcdName, &config)
+	if err != nil {
+		t.Fatal("failed to create a new state driver, err:", err)
+	}
+
+	// create common state
+	commonState = types.CommonState{
+		ID:          "0000",
+		StateDriver: stateDriver,
+	}
+
+	// create two authorizations
+	a1 = types.Authorization{
+		CommonState: commonState,
+		UUID:        "1111",
+		PrincipalID: "2222",
+		ClaimKey:    "tenant: Tenant1",
+		ClaimValue:  "devops",
+	}
+
+	a2 = types.Authorization{
+		CommonState: commonState,
+		UUID:        "3333",
+		PrincipalID: "2222",
+		ClaimKey:    "tenant: Tenant2",
+		ClaimValue:  "devops",
+	}
+	TestingT(t)
+}
+
+// TestInsertAuthz tests inserting an authz
+func TestInsertAuthz(t *testing.T) {
+
+	// write an authz
+	state.InsertAuthorization(&a1)
+
+	// read an authz
+	a, err := state.GetAuthorization(a1.UUID)
+	if err != nil {
+		t.Fatal("failed to get authz, err:", err)
+	}
+
+	// check that authz returned matches inserted authz
+	if a != a1 {
+		t.Fatal("failed to insert or get authz correctly")
+	}
+}
+
+// TestDeleteAuthorization tests deleting an authz
+func TestDeleteAuthorization(t *testing.T) {
+
+	// write an authz
+	state.InsertAuthorization(&a2)
+
+	// delete authz
+	state.DeleteAuthorization(a2.UUID)
+
+	// check that deleted authz cannot be retrieved
+	_, err := state.GetAuthorization(a2.UUID)
+	if err == nil {
+		t.Fatal("expecting read authz to fail")
+	}
+
+	// delete non-existent authz
+	err = state.DeleteAuthorization(a2.UUID)
+	if err == nil {
+		t.Fatal("expecting deletion of non-existent authz",
+			"to fail")
+	}
+
+}
+
+// TestListAuthorizationsByPrincipal tests listing authorizations by
+// principal
+func TestListAuthorizationsByPrincipal(t *testing.T) {
+
+	// write an authz
+	state.InsertAuthorization(&a1)
+	state.InsertAuthorization(&a2)
+
+	// list authz by principal
+	aList, err := state.ListAuthorizationsByPrincipal(a1.PrincipalID)
+	if err != nil {
+		t.Fatal("failed to list authz by principal, err: ", err)
+	}
+
+	// check that two authz instances are retrieved
+	if len(aList) != 2 {
+		t.Fatal("expecting exactly two authz to match principalID")
+	}
+}
+
+// TestDeleteAuthorizationsByPrincipal tests deleting an authorization
+// by principal
+func TestDeleteAuthorizationsByPrincipal(t *testing.T) {
+
+	// write an authz
+	state.InsertAuthorization(&a1)
+
+	// delete authz
+	err := state.DeleteAuthorizationsByPrincipal(a1.PrincipalID)
+	if err != nil {
+		t.Fatal("failed to delete authz by principal, err: ", err)
+	}
+
+	// list authz by principal
+	aList, err := state.ListAuthorizationsByPrincipal(a1.PrincipalID)
+	if err != nil {
+		t.Fatal("failed to list authz by principal, err: ", err)
+	}
+
+	// expecting to not find deleted authz
+	if len(aList) != 0 {
+		t.Fatal("failed to delete authz by principal")
+	}
+}
+
+// TestListAuthorizationsByClaim tests listing authorizations
+// by claim
+func TestListAuthorizationsByClaim(t *testing.T) {
+
+	// write an authz
+	state.InsertAuthorization(&a1)
+	state.InsertAuthorization(&a2)
+
+	// test existing claim key
+	aList, err := state.ListAuthorizationsByClaim(a1.ClaimKey)
+	if err != nil {
+		t.Fatal("failed to list authz by claim, err: ", err)
+	}
+
+	// check that exactly one authz is returned
+	if len(aList) != 1 {
+		t.Fatal("failed to correctly list authz by claim")
+	}
+
+	// test non-existing claim key
+	aList, err = state.ListAuthorizationsByClaim("tenant: TenantX")
+	if err != nil {
+		t.Fatal("failed to correctly list authz by claim, err: ", err)
+	}
+
+	// check that 0 authz instances are returned
+	if len(aList) != 0 {
+		t.Fatal("failed to correctly list authz by claim")
+	}
+}
+
+// TestDeleteAuthorizationsByClaim tests deleting authorizations
+// by claim
+func TestDeleteAuthorizationsByClaim(t *testing.T) {
+
+	// write an authz
+	state.InsertAuthorization(&a1)
+
+	// delete authz by claim
+	err := state.DeleteAuthorizationsByClaim(a1.ClaimKey)
+	if err != nil {
+		t.Fatal("failed to delete authz's by principal, err: ", err)
+	}
+
+	// test that listing deleted authz should not return any hits
+	aList, err := state.ListAuthorizationsByClaim(a1.ClaimKey)
+	if err != nil {
+		t.Fatal("failed to list authz by claim, err: ", err)
+	}
+
+	if len(aList) != 0 {
+		t.Fatal("failed to delete authz's by claim")
+	}
+}
+
+// TestListAuthorizationsByClaimAndPrincipal tests listing authorizations
+// by claim and principal
+func TestListAuthorizationsByClaimAndPrincipal(t *testing.T) {
+
+	// write an authz
+	state.InsertAuthorization(&a1)
+	state.InsertAuthorization(&a2)
+
+	// test listing by existing claim key and principal
+	aList, err := state.ListAuthorizationsByClaimAndPrincipal(a1.ClaimKey, a1.PrincipalID)
+	if err != nil {
+		t.Fatal("failed to list authz by claim and principal, err: ", err)
+	}
+
+	if len(aList) != 1 {
+		t.Fatal("failed to correctly list authz by claim and principal")
+	}
+
+	// test listing by non-existing claim key
+	aList, err = state.ListAuthorizationsByClaimAndPrincipal("tenant: TenantX", a1.PrincipalID)
+	if err != nil {
+		t.Fatal("failed to correctly list authz by claim and principal, err: ", err)
+	}
+	if len(aList) != 0 {
+		t.Fatal("failed to correctly list authz by claim and principal")
+	}
+
+	// test listing by non-existing principal
+	aList, err = state.ListAuthorizationsByClaimAndPrincipal(a1.ClaimKey, "1234")
+	if err != nil {
+		t.Fatal("failed to correctly list authz by claim and principal, err: ", err)
+	}
+
+	if len(aList) != 0 {
+		t.Fatal("failed to correctly list authz by claim and principal")
+	}
+}

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/contiv/ccn_proxy/common"
 	"github.com/contiv/ccn_proxy/common/test"
 	"github.com/contiv/ccn_proxy/common/types"
 	"github.com/contiv/ccn_proxy/proxy"
+	"github.com/contiv/ccn_proxy/state"
 	"github.com/contiv/ccn_proxy/usermgmt"
 
 	. "gopkg.in/check.v1"
@@ -32,7 +32,7 @@ func Test(t *testing.T) {
 	datastore := test.GetDatastore()
 	datastoreAddress := test.GetDatastoreAddress()
 
-	if err := common.InitializeStateDriver(datastoreAddress); err != nil {
+	if err := state.InitializeStateDriver(datastoreAddress); err != nil {
 		log.Fatalln(err)
 	}
 

--- a/usermgmt/db.go
+++ b/usermgmt/db.go
@@ -1,19 +1,21 @@
 package usermgmt
 
-import "path"
+import (
+	"github.com/contiv/ccn_proxy/common/types"
+	"path"
+)
 
 // This file contains all DS constants + functions related to local user management.
 
 // various data store paths.
 var (
-	root           = "/ccn_proxy"
 	RootLocalUsers = "local_users"
 	RootPrincipals = "principals"
 )
 
 // GetPath joins the given list of strings using path separator with `root` data store path.
 func GetPath(strs ...string) string {
-	str := root
+	str := types.CCNProxyDir
 	for _, s := range strs {
 		str = path.Join(str, s)
 	}

--- a/usermgmt/local.go
+++ b/usermgmt/local.go
@@ -8,6 +8,7 @@ import (
 	"github.com/contiv/ccn_proxy/common"
 	ccnerrors "github.com/contiv/ccn_proxy/common/errors"
 	"github.com/contiv/ccn_proxy/common/types"
+	"github.com/contiv/ccn_proxy/state"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -85,7 +86,7 @@ func getLocalUser(username string, stateDrv types.StateDriver) (*types.InternalL
 //  []types.InternalLocalUser: slice of local users
 //  error: as returned by consecutive func calls
 func GetLocalUsers() ([]*types.InternalLocalUser, error) {
-	stateDrv, err := common.GetStateDriver()
+	stateDrv, err := state.GetStateDriver()
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ func GetLocalUsers() ([]*types.InternalLocalUser, error) {
 //  *types.InternalLocalUser: reference to the internal representation of the local user object
 //  error: as returned by getLocalUser(..)
 func GetLocalUser(username string) (*types.InternalLocalUser, error) {
-	stateDrv, err := common.GetStateDriver()
+	stateDrv, err := state.GetStateDriver()
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +155,7 @@ func DeleteLocalUser(username string) error {
 		return ccnerrors.ErrIllegalOperation
 	}
 
-	stateDrv, err := common.GetStateDriver()
+	stateDrv, err := state.GetStateDriver()
 	if err != nil {
 		return err
 	}
@@ -184,7 +185,7 @@ func DeleteLocalUser(username string) error {
 // return Values:
 //  error: ccnerrors.ErrKeyExists if the user already exists or any relevant error from state driver
 func AddLocalUser(user *types.InternalLocalUser) error {
-	stateDrv, err := common.GetStateDriver()
+	stateDrv, err := state.GetStateDriver()
 	if err != nil {
 		return err
 	}

--- a/usermgmt/local_test.go
+++ b/usermgmt/local_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/contiv/ccn_proxy/common"
 	ccnerrors "github.com/contiv/ccn_proxy/common/errors"
 	"github.com/contiv/ccn_proxy/common/test"
 	"github.com/contiv/ccn_proxy/common/types"
+	"github.com/contiv/ccn_proxy/state"
 	uuid "github.com/satori/go.uuid"
 
 	. "gopkg.in/check.v1"
@@ -35,7 +35,7 @@ func (s *usermgmtSuite) SetUpSuite(c *C) {
 	datastoreAddress := test.GetDatastoreAddress()
 
 	test.CleanupDatastore(datastore, datastorePaths)
-	if err := common.InitializeStateDriver(datastoreAddress); err != nil {
+	if err := state.InitializeStateDriver(datastoreAddress); err != nil {
 		log.Fatalln(err)
 	}
 


### PR DESCRIPTION
- This API allows us to abstract away storing, retrieving
and deleting authorizations in the state store.
- Added new endpoints .../authorizations to allow POST,
GET, DELETE, UPDATE and LIST of all tenant-based authorizations

Running unit tests:
make unit-tests

To Do: 
- Convert unit tests to use suites: https://github.com/contiv/ccn_proxy/issues/18
- Add system tests for authz workflow
- Allow for the case when a principal can have access to multiple tenants.

**Examples for using the API:**

_Login:_
`curl -v -k -H "Content-Type: application/json" -d '{"username":"admin", "password":"admin"}' https://172.16.105.130:9999/api/v1/ccn_proxy/login`

_Add Tenant authorization:_
`curl -v -k -H "Content-Type: application/json" -H "X-Auth-Token <token>" -d '{"tenantName":"tenantA", "username":"user1", "local":true}' https://<host_ip>:9999/api/v1/ccn_proxy/authz/tenant`

_Get tenant authorization:_
`curl -v -k -X GET -H "Content-Type: application/json" -H "X-Auth-Token <token>" https://<host_ip>:9999/api/v1/ccn_proxy/authz/tenant/a983cdf4-1469-421e-90b5-4e33f35c1003`

_Update tenant authorization:_
`curl -v -k -X PATCH -H "Content-Type: application/json" -H "X-Auth-Token <token>" -d '{"tenantName":"tenantB", "username":"user2", "local":true}' https://<host_ip>:9999/api/v1/ccn_proxy/authz/tenant/a983cdf4-1469-421e-90b5-4e33f35c1003`

_Delete tenant authorization:_
`curl -v -k -X DELETE -H "Content-Type: application/json" -H "X-Auth-Token <token>" https://<host_ip>:9999/api/v1/ccn_proxy/authz/tenant/a983cdf4-1469-421e-90b5-4e33f35c1003`

Signed-off-by: selvikadirvel@gmail.com