### PR TITLE
Removed an unnecessary time.Sleep from runTest() by making ProxyServer.Stop() and MockServer.Stop() blocking calls

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -46,10 +46,10 @@ type Config struct {
 // Server represents a proxy server which can be running.
 type Server struct {
 	config        *Config        // holds all the configuration for the proxy server
-	stopChan      chan bool      // used to shut down the server
 	listener      net.Listener   // the actual HTTPS server
-	wg            sync.WaitGroup // used to avoid a race condition when shutting down
+	stopChan      chan bool      // used to shut down the server
 	useKeepalives bool           // controls whether the HTTPS server supports keepalives
+	wg            sync.WaitGroup // used to avoid a race condition when shutting down
 }
 
 // Init initializes anything the server requires before it can be used.
@@ -161,13 +161,14 @@ func (s *Server) Serve() {
 	<-s.stopChan
 	log.Debug("Received stop message, shutting down proxy")
 	s.listener.Close()
-
-	s.wg.Wait()
 }
 
 // Stop stops a running HTTP proxy listener.
 func (s *Server) Stop() {
 	s.stopChan <- true
+
+	// wait until the listener has actually been stopped
+	s.wg.Wait()
 }
 
 func addRoutes(s *Server, router *mux.Router) {

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -111,8 +111,6 @@ func runTest(f func(*proxy.Server, *MockServer)) {
 
 	ms.Stop()
 	p.Stop()
-
-	time.Sleep(25 * time.Millisecond)
 }
 
 // login returns the user's token or returns an error if authentication fails.

--- a/systemtests/mock_server.go
+++ b/systemtests/mock_server.go
@@ -76,11 +76,12 @@ func (ms *MockServer) Serve() {
 	<-ms.stopChan
 
 	ms.listener.Close()
-
-	ms.wg.Wait()
 }
 
 // Stop stops the mock server.
 func (ms *MockServer) Stop() {
 	ms.stopChan <- true
+
+	// wait until the listener has actually been stopped
+	ms.wg.Wait()
 }


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>