### PR TITLE
state: Fix etcd ReadAll() logic

### DIFF
--- a/state/consulstatedriver_test.go
+++ b/state/consulstatedriver_test.go
@@ -42,6 +42,12 @@ func TestConsulStateDriverRead(t *testing.T) {
 	commonTestStateDriverRead(t, driver)
 }
 
+// Test to check `ReadAll` from KV store
+func TestConsulStateDriverReadAll(t *testing.T) {
+	driver := setupConsulDriver(t)
+	commonTestStateDriverReadAll(t, driver)
+}
+
 func TestConsulStateDriverWriteState(t *testing.T) {
 	driver := setupConsulDriver(t)
 	commonTestStateDriverWriteState(t, driver)

--- a/state/etcdstatedriver_test.go
+++ b/state/etcdstatedriver_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	ccnerrors "github.com/contiv/ccn_proxy/common/errors"
 	"github.com/contiv/ccn_proxy/common/types"
 	. "gopkg.in/check.v1"
 )
@@ -83,6 +84,13 @@ func commonTestStateDriverRead(t *testing.T, d types.StateDriver) {
 		t.Fatalf("read bytes don't match written bytes. Wrote: %v Read: %v",
 			testBytes, readBytes)
 	}
+
+	// test `ErrKeyNotFound`
+	key = "/xxx/yyy"
+	if _, err := d.Read(key); err != ccnerrors.ErrKeyNotFound {
+		t.Fatalf("expected `ErrKeyNotFound`, found: %s", err)
+	}
+
 }
 
 // Test helper function to check writes to KV store
@@ -438,6 +446,13 @@ func commonTestStateDriverReadAll(t *testing.T, d types.StateDriver) {
 			t.Fatalf("read bytes don't match written bytes. Wrote: %v Read: %v",
 				testBytes, rbytes)
 		}
+	}
+
+	// test `ErrKeyNotFound`
+	key := "/xxx/yyy"
+
+	if _, err := d.ReadAll(key); err != ccnerrors.ErrKeyNotFound {
+		t.Fatalf("expected `ErrKeyNotFound`, found: %s", err)
 	}
 }
 


### PR DESCRIPTION
`ErrKeyNotFound` case is not handled in `ReadAll()`. `Consul` handles this case but not `Etcd` driver.

NOTE: DELETE can delete the entire path if there is no child; In such case, `ReadAll()` should return ErrKeyNotFound

@jojimt I see similar behavior in `netplugin` but I'm not sure how the netplugin callers handle these cases. 
https://github.com/contiv/netplugin/blob/68caa641787a75a571d44dd9ac5631d40c7bc7b8/state/etcdstatedriver.go#L104
https://github.com/contiv/netplugin/blob/68caa641787a75a571d44dd9ac5631d40c7bc7b8/state/etcdstatedriver.go#L130

Read() logic also needs to be changed, Please check here  https://github.com/contiv/ccn_proxy/pull/26/commits/3541075acc1df897cae189c788a008e19493c473

Signed-off-by: Yuva Shankar <yuva29@users.noreply.github.com>