### PR TITLE
Fixes list authorizations error (Issue #86)

### DIFF
--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -521,7 +521,7 @@ func listTenantAuthorizations(token *auth.Token, w http.ResponseWriter, req *htt
 		httpStatus = http.StatusOK
 
 		// convert authorizations to authorization reply msgs
-		var authzReplyList []GetAuthorizationReply
+		authzReplyList := []GetAuthorizationReply{}
 		for _, authz := range authzList {
 			authzReply := convertAuthz(authz)
 			authzReplyList = append(authzReplyList, authzReply)

--- a/state/authz.go
+++ b/state/authz.go
@@ -83,7 +83,7 @@ func ListAuthorizations() (
 		return nil, ccnerrors.ErrReadingFromStore
 	}
 
-	var list []types.Authorization
+	list := []types.Authorization{}
 	for _, auth := range allAuthZList {
 		tmp, ok := auth.(*types.Authorization)
 		if ok {
@@ -124,7 +124,7 @@ func ListAuthorizationsByPrincipal(ID string) (
 		return nil, ccnerrors.ErrReadingFromStore
 	}
 
-	var match []types.Authorization
+	match := []types.Authorization{}
 	for _, auth := range allAuthZList {
 		tmp, ok := auth.(*types.Authorization)
 		if ok {
@@ -215,7 +215,7 @@ func ListAuthorizationsByClaim(claim string) (
 		return nil, ccnerrors.ErrReadingFromStore
 	}
 
-	var match []types.Authorization
+	match := []types.Authorization{}
 	for _, auth := range allAuthZList {
 		tmp, ok := auth.(*types.Authorization)
 		if ok {
@@ -304,7 +304,7 @@ func ListAuthorizationsByClaimAndPrincipal(claim string, ID string) (
 		return nil, ccnerrors.ErrReadingFromStore
 	}
 
-	var match []types.Authorization
+	match := []types.Authorization{}
 	for _, auth := range allAuthZList {
 		tmp, ok := auth.(*types.Authorization)
 		if ok {


### PR DESCRIPTION
Fixes https://github.com/contiv/ccn/issues/86

Tested to ensure that when /ccn_proxy/authorizations in the KV store is empty, GET on /ccn_proxy/authorizations returns a [] instead of null.

Signed-off-by: selvikadirvel@gmail.com