### PR TITLE
Claims management for authz

### DIFF
--- a/auth/local/local.go
+++ b/auth/local/local.go
@@ -34,7 +34,6 @@ func Authenticate(username, password string) ([]string, error) {
 		return nil, ccnerrors.ErrAccessDenied
 	}
 
-	// local user's JWT will only contain the `username` + default claims (exp, role, etc.. )
 	// user.Username is the PrincipalName for localuser
 	return []string{user.Username}, nil
 }

--- a/auth/policy.go
+++ b/auth/policy.go
@@ -68,7 +68,16 @@ func (authZ *Token) checkTenantPolicy(tenant types.Tenant, desiredAccess interfa
 		return ccnerrors.NewError(ccnerrors.Internal, msg)
 	}
 
-	// check for explicit authorization to the tenant
+	// Gather tenant authorizations for principals claim present in token
+	// and look for authorizations for given tenant with desiredAccess. We
+	// don't cache authorizations in token itself, rather we rely on
+	// lookups in authorization database.
+	//
+	// NOTE: Once we move to an external authz provider model, we will
+	// potentially have to modify this workflow to return tokens that
+	// include exact desired claims. For an example, see docker registry
+	// oauth integration.
+	//
 	claims := authZ.tkn.Claims.(jwt.MapClaims)
 	if v, ok := claims[claimStr]; ok {
 

--- a/common/types/test/authz_test.go
+++ b/common/types/test/authz_test.go
@@ -132,11 +132,11 @@ func TestAuthZReadAll(t *testing.T) {
 
 	// check if any of the read values match 1st written value
 	if !(*tmp1 == a1 || *tmp2 == a1) {
-		t.Fatal("Neither read values:", *tmp1, " match written value:", a1)
+		t.Fatal("Neither read values:", *tmp1, *tmp2, " match written value:", a1)
 	}
 	// check if any of the read values match 2nd written value
 	if !(*tmp1 == a2 || *tmp2 == a2) {
-		t.Fatal("Neither read values:", *tmp2, " match written value:", a2)
+		t.Fatal("Neither read values:", *tmp1, *tmp2, " match written value:", a2)
 	}
 
 }

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -9,6 +9,11 @@ const (
 	// TenantClaimKey is a prefix added to Claim keys in the
 	// authorization or token object to represent tenants
 	TenantClaimKey = "tenant:"
+
+	// RoleClaimKey is a const string which represents highest
+	// available role available to a principal in token object or
+	// authorization db
+	RoleClaimKey = "role"
 )
 
 // RoleType each role type is associated with a group and set of capabilities

--- a/db/constants.go
+++ b/db/constants.go
@@ -6,7 +6,7 @@ import (
 	"github.com/contiv/ccn_proxy/common/types"
 )
 
-// This file contains all DS constants + functions related to local user management.
+// This file contains all DS constants
 
 // various data store paths.
 var (

--- a/db/local.go
+++ b/db/local.go
@@ -205,30 +205,3 @@ func AddLocalUser(user *types.LocalUser) error {
 		return err
 	}
 }
-
-// AddDefaultUsers adds pre-defined  users(admin,ops) to the system.
-// Default users cannot be changed(update/delete) anytime.
-func AddDefaultUsers() error {
-	for _, userR := range []types.RoleType{types.Admin, types.Ops} {
-		log.Printf("Adding local user %q to the system", userR.String())
-
-		localUser := types.LocalUser{
-			Username: userR.String(),
-			// default user accounts are `enabled` always; it cannot be disabled
-			Disable:  false,
-			Password: userR.String(),
-			// FirstName, LastName = "" for built-in users
-		}
-
-		err := AddLocalUser(&localUser)
-		if err == nil || err == ccnerrors.ErrKeyExists {
-			continue
-		}
-
-		// TODO: add default authorization as well
-
-		return err
-	}
-
-	return nil
-}

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/contiv/ccn_proxy/auth"
 	"github.com/contiv/ccn_proxy/common"
-	"github.com/contiv/ccn_proxy/db"
 	"github.com/contiv/ccn_proxy/proxy"
 	"github.com/contiv/ccn_proxy/state"
 
@@ -35,7 +35,7 @@ func performInitialSetup() {
 	log.Println("Performing initial setup")
 
 	log.Println("Adding default users with default passwords")
-	if err := db.AddDefaultUsers(); err != nil {
+	if err := auth.AddDefaultUsers(); err != nil {
 		log.Fatalln(err)
 		// exit with a non-zero error code.
 		// this can be used by installers, etc. to determine whether the

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -245,6 +245,7 @@ func addUserMgmtRoutes(router *mux.Router) {
 
 // addAuthorizationRoutes adds authorization routes to the mux.Router
 // All authorization management routes are admin-only.
+// FIXME: These routes should also handle admin role authorization that applies to all tenants
 func addAuthorizationRoutes(router *mux.Router) {
 	router.Path("/api/v1/ccn_proxy/authorizations").Methods("POST").HandlerFunc(adminOnly(addTenantAuthorization))
 	router.Path("/api/v1/ccn_proxy/authorizations/{authzUUID}").Methods("DELETE").HandlerFunc(adminOnly(deleteTenantAuthorization))

--- a/state/authz.go
+++ b/state/authz.go
@@ -286,7 +286,7 @@ func DeleteAuthorizationsByClaim(claim string) error {
 //  error: Any error encountered when reading from the KV store
 //         nil if operation is successful
 //
-func ListAuthorizationsByClaimAndPrincipal(claim string, ID string) (
+func ListAuthorizationsByClaimAndPrincipal(claim string, principal string) (
 	[]types.Authorization, error) {
 
 	defer common.Untrace(common.Trace())
@@ -308,7 +308,7 @@ func ListAuthorizationsByClaimAndPrincipal(claim string, ID string) (
 	for _, auth := range allAuthZList {
 		tmp, ok := auth.(*types.Authorization)
 		if ok {
-			if (tmp.ClaimKey == claim) && (tmp.PrincipalID == ID) {
+			if (tmp.ClaimKey == claim) && (tmp.PrincipalName == principal) {
 				match = append(match, *tmp)
 			}
 		}

--- a/state/test/authz_test.go
+++ b/state/test/authz_test.go
@@ -38,19 +38,21 @@ func Test(t *testing.T) {
 
 	// create two authorizations
 	a1 = types.Authorization{
-		CommonState: commonState,
-		UUID:        "1111",
-		PrincipalID: "2222",
-		ClaimKey:    "tenant: Tenant1",
-		ClaimValue:  "devops",
+		CommonState:   commonState,
+		UUID:          "1111",
+		PrincipalID:   "2222",
+		PrincipalName: "2222",
+		ClaimKey:      "tenant: Tenant1",
+		ClaimValue:    "devops",
 	}
 
 	a2 = types.Authorization{
-		CommonState: commonState,
-		UUID:        "3333",
-		PrincipalID: "2222",
-		ClaimKey:    "tenant: Tenant2",
-		ClaimValue:  "devops",
+		CommonState:   commonState,
+		UUID:          "3333",
+		PrincipalID:   "2222",
+		PrincipalName: "2222",
+		ClaimKey:      "tenant: Tenant2",
+		ClaimValue:    "devops",
 	}
 	TestingT(t)
 }

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/contiv/ccn_proxy/auth"
 	"github.com/contiv/ccn_proxy/common/test"
 	"github.com/contiv/ccn_proxy/common/types"
 	"github.com/contiv/ccn_proxy/db"
@@ -40,9 +41,10 @@ func Test(t *testing.T) {
 	test.CleanupDatastore(datastore, []string{
 		db.GetPath(db.RootLocalUsers),
 		db.GetPath(db.RootLdapConfiguration),
+		db.GetPath("authorizations"),
 	})
 
-	if err := db.AddDefaultUsers(); err != nil {
+	if err := auth.AddDefaultUsers(); err != nil {
 		log.Fatalln(err)
 	}
 


### PR DESCRIPTION
1. Add default admin authorization for built in admin user.
2. Add principals claim to login token to represent local user/ldap
groups associated with a AD user
3. Use authorizations to add role claim to token that is used by UI for
role differentiation
4. Use authorizations to generate role claim at runtime to perform RBAC
on API calls