### PR TITLE
AD setup for dev testing + Add systemtests to test LDAP authentication

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -26,7 +26,9 @@ func Authenticate(username, password string) (string, error) {
 		return generateToken(userPrincipals, username) // local authentication succeeded!
 	}
 
-	if err == ccnerrors.ErrUserNotFound {
+	// Same username can be there in both local setup and LDAP.
+	// So, we try LDAP if `access is denied` from local authentication; coz, the same user(name) could also be part of LDAP.
+	if err == ccnerrors.ErrUserNotFound || err == ccnerrors.ErrAccessDenied {
 		userPrincipals, err = ldap.Authenticate(username, password)
 		if err == nil {
 			return generateToken(userPrincipals, username) // ldap authentication succeeded!

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -7,10 +7,12 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 
 	"github.com/contiv/ccn_proxy/auth"
+	"github.com/contiv/ccn_proxy/common"
 	"github.com/contiv/ccn_proxy/common/test"
 	"github.com/contiv/ccn_proxy/common/types"
 	"github.com/contiv/ccn_proxy/db"
@@ -41,6 +43,10 @@ func Test(t *testing.T) {
 	if err := state.InitializeStateDriver(datastoreAddress); err != nil {
 		log.Fatalln(err)
 	}
+
+	// set `tls_key_file` in Globals
+	exec.Command("/bin/sh", "-c", "make generate-certificate")
+	common.Global().Set("tls_key_file", "../local_certs/local.key")
 
 	// cleanup users and principals
 	test.CleanupDatastore(datastore, []string{

--- a/systemtests/ldap_management_test.go
+++ b/systemtests/ldap_management_test.go
@@ -1,0 +1,22 @@
+package systemtests
+
+import . "gopkg.in/check.v1"
+
+// TODO: add system tests to test LDAP management CRUD operations
+
+// addLdapConfiguration helper function for the tests
+func (s *systemtestSuite) addLdapConfiguration(c *C, token, data string) {
+	endpoint := "/api/v1/ccn_proxy/ldap_configuration"
+
+	resp, _ := proxyPost(c, token, endpoint, []byte(data))
+	c.Assert(resp.StatusCode, Equals, 201)
+}
+
+// deleteLdapConfiguration helper function for the tests
+func (s *systemtestSuite) deleteLdapConfiguration(c *C, token string) {
+	endpoint := "/api/v1/ccn_proxy/ldap_configuration"
+
+	resp, body := proxyDelete(c, token, endpoint)
+	c.Assert(resp.StatusCode, Equals, 204)
+	c.Assert(body, DeepEquals, []byte{})
+}


### PR DESCRIPTION
This PR addresses the following

1. Fixes https://github.com/contiv/ccn/issues/87

`Active Directory is running on : 10.193.231.158:5678`. Anyone who has lab access should be able reach to it. If it goes down for any reason, below are the steps to bring it back
```
If the VM is powered off, start using the below command

nohup VBoxHeadless --startvm Windows\ Server\ 2008 --vrde on > ad_server.log 2>&1 & 
```
Also, If you want to change something in AD,  Please remote desktop to `10.193.231.158`. 

`.vdi, .vbox` files are located in `/home/yuva/windows_server_2008/`

NOTE:  user credentials for this AD setup can be found in system test.

@dseevr  has access to my dev server.  @rhim Let me know if you want access to my server.

Thanks @dseevr for helping me set this up.

Signed-off-by: Yuva Shankar <yuva29@users.noreply.github.com>