### PR TITLE
Changed default port of proxy/UI to 10000 and local netmaster to 9999

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,13 +59,13 @@ func processFlags() {
 	flag.StringVar(
 		&listenAddress,
 		"listen-address",
-		":9999",
+		":10000",
 		"address to listen to HTTP requests on",
 	)
 	flag.StringVar(
 		&netmasterAddress,
 		"netmaster-address",
-		"localhost:9998",
+		"localhost:9999",
 		"address of the upstream netmaster",
 	)
 	flag.StringVar(


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

Because netmaster uses port 9999 and we're not truly a transparent proxy, we should not use port 9999 as the default for the UI/proxy.  10000 is a nice number to use instead.  😄 