### PR TITLE
Use .dockerignore to ignore everything under build/dependencies/contiv-ui we don't need

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+
+# don't import anything from the UI except the /app folder where the
+# actual site and compiled assets live.
+build/dependencies/contiv-ui
+!build/dependencies/contiv-ui/app


### PR DESCRIPTION
This speeds up builds by over 2x on my server.

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>