### PR TITLE
State drivers now ensure that their data directories exist when initialized

### DIFF
--- a/common/types/authz.go
+++ b/common/types/authz.go
@@ -22,6 +22,12 @@ const (
 	AuthZDir = CCNProxyDir + "/" + "authorizations"
 )
 
+var DatastoreDirectories = []string{
+	AuthZDir,
+	CCNProxyDir + "/local_users",
+	CCNProxyDir + "/principals",
+}
+
 //
 // Authorization represents the dynamic policy that defines mapping of
 // principals and their access claims to entities with certain capabilities.

--- a/common/types/state.go
+++ b/common/types/state.go
@@ -25,6 +25,8 @@ type StateDriver interface {
 	Init(config *KVStoreConfig) error
 	Deinit()
 
+	Mkdir(string) error
+
 	// XXX: the following raw versions of Read, Write, ReadAll and WatchAll
 	// could be removed, since it is not used directly for now
 	Read(key string) ([]byte, error)

--- a/state/consulstatedriver_test.go
+++ b/state/consulstatedriver_test.go
@@ -31,6 +31,12 @@ func TestConsulStateDriverInitInvalidConfig(t *testing.T) {
 	commonTestStateDriverInitInvalidConfig(t, driver)
 }
 
+// Test to check directory creation in KV store
+func TestConsulStateDriverMkdir(t *testing.T) {
+	driver := setupConsulDriver(t)
+	commonTestStateDriverMkdir(t, driver, "test_mkdir/")
+}
+
 // Test to check writes to KV store
 func TestConsulStateDriverWrite(t *testing.T) {
 	driver := setupConsulDriver(t)

--- a/state/etcdstatedriver_test.go
+++ b/state/etcdstatedriver_test.go
@@ -54,6 +54,27 @@ func commonTestStateDriverInitInvalidConfig(t *testing.T, d types.StateDriver) {
 	}
 }
 
+// Test helper function to check directory creation in KV store
+// NOTE: dir is passed as an argument because etcd requires a slash at
+//       the beginning while consul requires a trailing slash and both
+//       test suites call this function.
+func commonTestStateDriverMkdir(t *testing.T, d types.StateDriver, dir string) {
+	_, err := d.ReadAll(dir)
+	if err == nil {
+		t.Fatalf("expected ReadAll to %s to fail", dir)
+	}
+
+	err = d.Mkdir(dir)
+	if err != nil {
+		t.Fatalf("failed to create %s: %s", dir, err)
+	}
+
+	_, err = d.ReadAll(dir)
+	if err != nil {
+		t.Fatalf("failed to read dir at %s: %s", dir, err)
+	}
+}
+
 // Test helper function to check writes to KV store
 func commonTestStateDriverWrite(t *testing.T, d types.StateDriver) {
 	testBytes := []byte{0xb, 0xa, 0xd, 0xb, 0xa, 0xb, 0xe}
@@ -403,6 +424,12 @@ func TestEtcdStateDriverInit(t *testing.T) {
 func TestEtcdStateDriverInitInvalidConfig(t *testing.T) {
 	driver := &EtcdStateDriver{}
 	commonTestStateDriverInitInvalidConfig(t, driver)
+}
+
+// Test to check directory creation in KV store
+func TestEtcdStateDriverMkdir(t *testing.T) {
+	driver := setupEtcdDriver(t)
+	commonTestStateDriverMkdir(t, driver, "/test_mkdir")
 }
 
 // Test to check writes to KV store


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

Fixes https://github.com/contiv/ccn/issues/85