### PR TITLE
Added /health endpoint which returns the version + status of the proxy and its netmaster

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -17,6 +17,9 @@ const (
 	// LoginPath is the authentication endpoint on the proxy
 	LoginPath = "/api/v1/ccn_proxy/login"
 
+	// HealthCheckPath is the health check endpoint on the proxy
+	HealthCheckPath = "/health"
+
 	// VersionPath is the version endpoint on the proxy
 	VersionPath = "/version"
 
@@ -183,6 +186,11 @@ func addRoutes(s *Server, router *mux.Router) {
 	// Version endpoint
 	//
 	router.Path(VersionPath).Methods("GET").HandlerFunc(versionHandler(s.config.Version))
+
+	//
+	// Health check endpoint
+	//
+	router.Path(HealthCheckPath).Methods("GET").HandlerFunc(healthCheckHandler(s.config))
 
 	//
 	// Authentication endpoint


### PR DESCRIPTION
## Example responses

These are pretty-printed here, but the actual raw responses are not.

### Healthy response

```json
{
    "netmaster": {
        "status": "healthy",
        "version": "pv0.1-01-05-2017.23-41-24.UTC"
    },
    "status": "healthy",
    "version": "devbuild"
}
```

### Unhealthy response

```json
{
    "netmaster": {
        "reason": "failed to connect to netmaster: Get http://localhost:12345/version: dial tcp 127.0.0.1:12345: getsockopt: connection refused",
        "status": "unhealthy"
    },
    "status": "unhealthy",
    "version": "devbuild"
}
```

Fixes https://github.com/contiv/ccn/issues/154