### PR TITLE
Added Strict-Transport-Security header as a default response header

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -12,7 +12,7 @@ import (
 	auth_errors "github.com/contiv/auth_proxy/common/errors"
 )
 
-// GlobalMap is a map to hold variables(key:value pair) that can be accessed anywhere in ccc_proxy
+// GlobalMap is a map to hold variables(key:value pair) that can be accessed anywhere in auth_proxy
 type GlobalMap map[string]string
 
 var global GlobalMap
@@ -108,11 +108,15 @@ func Untrace(s string) {
 	log.Debug("Leaving: ", s)
 }
 
-// SetJSONContentType sets the Content-Type header to JSON.
-func SetJSONContentType(w http.ResponseWriter) {
+// SetDefaultResponseHeaders sets the default response headers.
+func SetDefaultResponseHeaders(w http.ResponseWriter) {
 	// the charset here is to work around a bug where Chrome does not parse JSON data properly:
 	// https://bugs.chromium.org/p/chromium/issues/detail?id=438464
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	// enable HSTS for six months
+	// we don't actually serve a non-HTTPS site, so this header ultimately does nothing
+	w.Header().Set("Strict-Transport-Security", "max-age=15768000")
 }
 
 // GetNetmasterVersion reaches out to the specified netmaster and retrieves

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -36,7 +36,7 @@ func serverError(w http.ResponseWriter, err error) {
 //     401 (authorization failed)
 //     500 (something broke)
 func loginHandler(w http.ResponseWriter, req *http.Request) {
-	common.SetJSONContentType(w)
+	common.SetDefaultResponseHeaders(w)
 
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
@@ -116,7 +116,7 @@ func (hcr *HealthCheckResponse) MarkUnhealthy() {
 // healthCheckHandler handles /health requests
 func healthCheckHandler(config *Config) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		common.SetJSONContentType(w)
+		common.SetDefaultResponseHeaders(w)
 
 		hcr := &HealthCheckResponse{
 			Status:  StatusHealthy, // default to being healthy
@@ -160,7 +160,7 @@ type VersionResponse struct {
 // versionHandler handles /version requests and returns the proxy version
 func versionHandler(version string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		common.SetJSONContentType(w)
+		common.SetDefaultResponseHeaders(w)
 
 		vr := &VersionResponse{Version: version}
 

--- a/proxy/helpers.go
+++ b/proxy/helpers.go
@@ -445,7 +445,7 @@ func isTokenValid(tokenStr string, w http.ResponseWriter) (bool, *auth.Token) {
 //  w: http response writer
 //
 func processStatusCodes(statusCode int, resp []byte, w http.ResponseWriter) {
-	common.SetJSONContentType(w)
+	common.SetDefaultResponseHeaders(w)
 	switch statusCode {
 	case http.StatusCreated, http.StatusOK:
 		w.WriteHeader(statusCode)

--- a/proxy/rbac.go
+++ b/proxy/rbac.go
@@ -84,7 +84,7 @@ func enforceRBAC(s *Server) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		vars := mux.Vars(req)
 
-		common.SetJSONContentType(w)
+		common.SetDefaultResponseHeaders(w)
 
 		isValid, token := isTokenValid(req.Header.Get("X-Auth-Token"), w)
 		if !isValid {

--- a/systemtests/basic_test.go
+++ b/systemtests/basic_test.go
@@ -148,20 +148,26 @@ func (s *systemtestSuite) TestRequestProxying(c *C) {
 		c.Assert(resp.StatusCode, Equals, 200)
 		c.Assert(data, Equals, string(body))
 
-		// check that the Content-Type header was set properly.
-		// we need to add a custom charset to work around a Chrome bug:
-		// https://bugs.chromium.org/p/chromium/issues/detail?id=438464
-		headerFound := false
+		// make sure that the expected headers are present
+
+		contentTypeHeaderFound := false
+		hstsHeaderFound := false
+
 		for name, headers := range resp.Header {
-			if name == "Content-Type" {
+			switch name {
+			case "Content-Type":
 				c.Assert(len(headers), Equals, 1)
 				c.Assert(headers[0], Equals, "application/json; charset=utf-8")
-				headerFound = true
-				break
+				contentTypeHeaderFound = true
+			case "Strict-Transport-Security":
+				c.Assert(len(headers), Equals, 1)
+				c.Assert(headers[0], Equals, "max-age=15768000")
+				hstsHeaderFound = true
 			}
 		}
 
-		c.Assert(headerFound, Equals, true)
+		c.Assert(contentTypeHeaderFound, Equals, true)
+		c.Assert(hstsHeaderFound, Equals, true)
 	})
 }
 

--- a/systemtests/mock_server.go
+++ b/systemtests/mock_server.go
@@ -38,7 +38,7 @@ func (ms *MockServer) Init() {
 // AddHardcodedResponse registers a HTTP handler func for `path' that returns `body'.
 func (ms *MockServer) AddHardcodedResponse(path string, body []byte) {
 	ms.mux.HandleFunc(path, func(w http.ResponseWriter, req *http.Request) {
-		common.SetJSONContentType(w)
+		common.SetDefaultResponseHeaders(w)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(body)
 	})


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

Fixes https://github.com/contiv/ccn/issues/158