### PR TITLE
Disabled TLS 1.0 in the proxy server configuration

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -144,7 +144,10 @@ func (s *Server) Serve() {
 		return
 	}
 
-	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS11,
+	}
 
 	s.listener, err = tls.Listen("tcp", s.config.ListenAddress, tlsConfig)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

Fixes https://github.com/contiv/ccn/issues/157

## Scan output

```
➜  nmap --script ssl-cert,ssl-enum-ciphers -p50000 localhost

Starting Nmap 7.01 ( https://nmap.org ) at 2017-01-23 14:34 PST
Nmap scan report for localhost (127.0.0.1)
Host is up (0.000091s latency).
Other addresses for localhost (not scanned): ::1
PORT      STATE SERVICE
50000/tcp open  ibm-db2
| ssl-enum-ciphers:
|   TLSv1.1:
|     ciphers:
|       TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA (secp256r1) - C
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 2048) - C
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|     compressors:
|       NULL
|     cipher preference: client
|   TLSv1.2:
|     ciphers:
|       TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA (secp256r1) - C
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 2048) - C
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
|     compressors:
|       NULL
|     cipher preference: client
|_  least strength: C

Nmap done: 1 IP address (1 host up) scanned in 0.57 seconds
```