### PR TITLE
UI is now served with Strict-Transport-Security response header

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -108,15 +108,25 @@ func Untrace(s string) {
 	log.Debug("Leaving: ", s)
 }
 
+// HSTSValue is the value of the Strict-Transport-Security header we set.
+// 15768000 = 6 months
+const HSTSValue = "max-age=15768000"
+
+// EnableHSTS adds the Strict-Transport-Security header.
+// it's a separate function because it's called from two different places.
+func EnableHSTS(w http.ResponseWriter) {
+	// enable HSTS for six months
+	// we don't actually serve a non-HTTPS site, so this header ultimately does nothing
+	w.Header().Set("Strict-Transport-Security", HSTSValue)
+}
+
 // SetDefaultResponseHeaders sets the default response headers.
 func SetDefaultResponseHeaders(w http.ResponseWriter) {
 	// the charset here is to work around a bug where Chrome does not parse JSON data properly:
 	// https://bugs.chromium.org/p/chromium/issues/detail?id=438464
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
-	// enable HSTS for six months
-	// we don't actually serve a non-HTTPS site, so this header ultimately does nothing
-	w.Header().Set("Strict-Transport-Security", "max-age=15768000")
+	EnableHSTS(w)
 }
 
 // GetNetmasterVersion reaches out to the specified netmaster and retrieves

--- a/systemtests/basic_test.go
+++ b/systemtests/basic_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/contiv/auth_proxy/common"
 	"github.com/contiv/auth_proxy/proxy"
 
 	. "gopkg.in/check.v1"
@@ -161,12 +162,34 @@ func (s *systemtestSuite) TestRequestProxying(c *C) {
 				contentTypeHeaderFound = true
 			case "Strict-Transport-Security":
 				c.Assert(len(headers), Equals, 1)
-				c.Assert(headers[0], Equals, "max-age=15768000")
+				c.Assert(headers[0], Equals, common.HSTSValue)
 				hstsHeaderFound = true
 			}
 		}
 
 		c.Assert(contentTypeHeaderFound, Equals, true)
+		c.Assert(hstsHeaderFound, Equals, true)
+	})
+}
+
+// TestUIResponseHeaders tests that the UI is sending back the expected headers.
+// TODO: test that assets are gzipped properly
+func (s *systemtestSuite) TestUIResponseHeaders(c *C) {
+	runTest(func(ms *MockServer) {
+		resp, _ := proxyGet(c, noToken, "/")
+		c.Assert(resp.StatusCode, Equals, 200)
+
+		hstsHeaderFound := false
+
+		for name, headers := range resp.Header {
+			switch name {
+			case "Strict-Transport-Security":
+				c.Assert(len(headers), Equals, 1)
+				c.Assert(headers[0], Equals, common.HSTSValue)
+				hstsHeaderFound = true
+			}
+		}
+
 		c.Assert(hstsHeaderFound, Equals, true)
 	})
 }


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

Fixes https://github.com/contiv/ccn/issues/158