### PR TITLE
Add auth_proxy cleanup file

### DIFF
--- a/ansible/roles/auth_proxy/tasks/cleanup.yml
+++ b/ansible/roles/auth_proxy/tasks/cleanup.yml
@@ -1,0 +1,4 @@
+---
+
+- name: stop auth-proxy container
+  service: name=auth-proxy state=stopped

--- a/install/ansible/install.sh
+++ b/install/ansible/install.sh
@@ -3,6 +3,7 @@
 
 # Ignore ansible ssh host key checking by default
 export ANSIBLE_HOST_KEY_CHECKING=False
+src_conf_path=""
 
 # Scheduler provider can be in kubernetes or swarm mode
 scheduler_provider=${CONTIV_SCHEDULER_PROVIDER:-"native-swarm"}

--- a/install/ansible/install_defaults.sh
+++ b/install/ansible/install_defaults.sh
@@ -1,4 +1,4 @@
-src_conf_path=/tmp/contiv/config
+src_conf_path=${src_conf_path:-`mktemp -d /tmp/contiv_install_XXXXX`}
 container_conf_path=/var/contiv
 
 # These paths are in the installer container

--- a/install/ansible/uninstall.sh
+++ b/install/ansible/uninstall.sh
@@ -3,6 +3,7 @@
 
 # Ignore ansible ssh host key checking by default
 export ANSIBLE_HOST_KEY_CHECKING=False
+src_conf_path=""
 
 # Scheduler provider can be in kubernetes or swarm mode
 scheduler_provider=${CONTIV_SCHEDULER_PROVIDER:-"native-swarm"}


### PR DESCRIPTION
Also changing the host mounted folder path for installer container to a dynamic temp folder, to allow running multiple installer instances from the same host - lab scenarios.
Host mounted path variable is not required inside the container, so src_conf_path is empty in the install/uninstall scripts.