### PR TITLE
/version and /health endpoints have now been namedspaced under /api/v1/auth_proxy/*

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -15,14 +15,17 @@ import (
 )
 
 const (
+	// V1Prefix is the API prefix for the v1 API
+	V1Prefix = "/api/v1/auth_proxy"
+
 	// LoginPath is the authentication endpoint on the proxy
-	LoginPath = "/api/v1/auth_proxy/login"
+	LoginPath = V1Prefix + "/login"
 
 	// HealthCheckPath is the health check endpoint on the proxy
-	HealthCheckPath = "/api/v1/auth_proxy/health"
+	HealthCheckPath = V1Prefix + "/health"
 
 	// VersionPath is the version endpoint on the proxy
-	VersionPath = "/api/v1/auth_proxy/version"
+	VersionPath = V1Prefix + "/version"
 
 	// uiDirectory is the location in the container where the baked-in UI lives
 	// and where an external UI directory can be bindmounted over using -v
@@ -263,26 +266,26 @@ func addNetmasterRoutes(s *Server, router *mux.Router) {
 // addUserMgmtRoutes adds user management routes to the mux.Router.
 // All user management routes are admin-only.
 func addUserMgmtRoutes(router *mux.Router) {
-	router.Path("/api/v1/auth_proxy/local_users").Methods("POST").HandlerFunc(adminOnly(addLocalUser))
-	router.Path("/api/v1/auth_proxy/local_users/{username}").Methods("DELETE").HandlerFunc(adminOnly(deleteLocalUser))
-	router.Path("/api/v1/auth_proxy/local_users/{username}").Methods("PATCH").HandlerFunc(adminOnly(updateLocalUser))
-	router.Path("/api/v1/auth_proxy/local_users/{username}").Methods("GET").HandlerFunc(adminOnly(getLocalUser))
-	router.Path("/api/v1/auth_proxy/local_users").Methods("GET").HandlerFunc(adminOnly(getLocalUsers))
+	router.Path(V1Prefix + "/local_users").Methods("POST").HandlerFunc(adminOnly(addLocalUser))
+	router.Path(V1Prefix + "/local_users/{username}").Methods("DELETE").HandlerFunc(adminOnly(deleteLocalUser))
+	router.Path(V1Prefix + "/local_users/{username}").Methods("PATCH").HandlerFunc(adminOnly(updateLocalUser))
+	router.Path(V1Prefix + "/local_users/{username}").Methods("GET").HandlerFunc(adminOnly(getLocalUser))
+	router.Path(V1Prefix + "/local_users").Methods("GET").HandlerFunc(adminOnly(getLocalUsers))
 }
 
 // addAuthorizationRoutes adds authorization routes to the mux.Router
 // All authorization management routes are admin-only.
 func addAuthorizationRoutes(router *mux.Router) {
-	router.Path("/api/v1/auth_proxy/authorizations").Methods("POST").HandlerFunc(adminOnly(addAuthorization))
-	router.Path("/api/v1/auth_proxy/authorizations/{authzUUID}").Methods("DELETE").HandlerFunc(adminOnly(deleteAuthorization))
-	router.Path("/api/v1/auth_proxy/authorizations/{authzUUID}").Methods("GET").HandlerFunc(adminOnly(getAuthorization))
-	router.Path("/api/v1/auth_proxy/authorizations").Methods("GET").HandlerFunc(adminOnly(listAuthorizations))
+	router.Path(V1Prefix + "/authorizations").Methods("POST").HandlerFunc(adminOnly(addAuthorization))
+	router.Path(V1Prefix + "/authorizations/{authzUUID}").Methods("DELETE").HandlerFunc(adminOnly(deleteAuthorization))
+	router.Path(V1Prefix + "/authorizations/{authzUUID}").Methods("GET").HandlerFunc(adminOnly(getAuthorization))
+	router.Path(V1Prefix + "/authorizations").Methods("GET").HandlerFunc(adminOnly(listAuthorizations))
 }
 
 // addLdapConfigurationMgmtRoutes adds LDAP configuration management routes to mux.Router.
 func addLdapConfigurationMgmtRoutes(router *mux.Router) {
-	router.Path("/api/v1/auth_proxy/ldap_configuration").Methods("POST").HandlerFunc(adminOnly(addLdapConfiguration))
-	router.Path("/api/v1/auth_proxy/ldap_configuration").Methods("GET").HandlerFunc(adminOnly(getLdapConfiguration))
-	router.Path("/api/v1/auth_proxy/ldap_configuration").Methods("DELETE").HandlerFunc(adminOnly(deleteLdapConfiguration))
-	router.Path("/api/v1/auth_proxy/ldap_configuration").Methods("PATCH").HandlerFunc(adminOnly(updateLdapConfiguration))
+	router.Path(V1Prefix + "/ldap_configuration").Methods("POST").HandlerFunc(adminOnly(addLdapConfiguration))
+	router.Path(V1Prefix + "/ldap_configuration").Methods("GET").HandlerFunc(adminOnly(getLdapConfiguration))
+	router.Path(V1Prefix + "/ldap_configuration").Methods("DELETE").HandlerFunc(adminOnly(deleteLdapConfiguration))
+	router.Path(V1Prefix + "/ldap_configuration").Methods("PATCH").HandlerFunc(adminOnly(updateLdapConfiguration))
 }

--- a/systemtests/auth_test.go
+++ b/systemtests/auth_test.go
@@ -34,7 +34,7 @@ func (s *systemtestSuite) TestAdminAuthorizationResponse(c *C) {
 		// TODO: Remove authorizations with delete user
 		s.deleteAuthorization(c, authz.AuthzUUID, adToken)
 
-		endpoint := "/api/v1/auth_proxy/authorizations/" + authz.AuthzUUID
+		endpoint := proxy.V1Prefix + "/authorizations/" + authz.AuthzUUID
 		resp, _ := proxyGet(c, adToken, endpoint)
 		c.Assert(resp.StatusCode, Equals, 404)
 	})
@@ -48,7 +48,7 @@ func (s *systemtestSuite) TestTenantAuthorizationResponse(c *C) {
 	runTest(func(ms *MockServer) {
 		// grant ops access to username, tenant name is required and should not be ignored
 		data := `{"PrincipalName":"` + username + `","local":true,"role":"` + types.Ops.String() + `","tenantName":""}`
-		endpoint := "/api/v1/auth_proxy/authorizations"
+		endpoint := proxy.V1Prefix + "/authorizations"
 
 		resp, _ := proxyPost(c, adToken, endpoint, []byte(data))
 		c.Assert(resp.StatusCode, Equals, 400)
@@ -71,7 +71,7 @@ func (s *systemtestSuite) TestTenantAuthorizationResponse(c *C) {
 		// TODO: Remove authorizations with delete user
 		s.deleteAuthorization(c, authz.AuthzUUID, adToken)
 
-		endpoint = "/api/v1/auth_proxy/authorizations/" + authz.AuthzUUID
+		endpoint = proxy.V1Prefix + "/authorizations/" + authz.AuthzUUID
 		resp, _ = proxyGet(c, adToken, endpoint)
 		c.Assert(resp.StatusCode, Equals, 404)
 	})
@@ -87,7 +87,7 @@ func (s *systemtestSuite) TestBuiltInAdminAuthorizationImmortality(c *C) {
 
 	adminAuthUUID := auths[0].UUID
 
-	baseURL := "/api/v1/auth_proxy/authorizations"
+	baseURL := proxy.V1Prefix + "/authorizations"
 
 	//
 	// try to delete the sole authorization
@@ -108,7 +108,7 @@ func (s *systemtestSuite) TestBuiltInAdminAuthorizationImmortality(c *C) {
 
 // addAuthorization helper function for the tests
 func (s *systemtestSuite) addAuthorization(c *C, data, token string) proxy.GetAuthorizationReply {
-	endpoint := "/api/v1/auth_proxy/authorizations"
+	endpoint := proxy.V1Prefix + "/authorizations"
 
 	resp, body := proxyPost(c, token, endpoint, []byte(data))
 	c.Assert(resp.StatusCode, Equals, 201)
@@ -120,7 +120,7 @@ func (s *systemtestSuite) addAuthorization(c *C, data, token string) proxy.GetAu
 
 // getAuthorization helper function for the tests
 func (s *systemtestSuite) getAuthorization(c *C, authzUUID, token string) proxy.GetAuthorizationReply {
-	endpoint := "/api/v1/auth_proxy/authorizations/" + authzUUID
+	endpoint := proxy.V1Prefix + "/authorizations/" + authzUUID
 
 	resp, body := proxyGet(c, token, endpoint)
 	c.Assert(resp.StatusCode, Equals, 200)
@@ -132,7 +132,7 @@ func (s *systemtestSuite) getAuthorization(c *C, authzUUID, token string) proxy.
 
 // deleteAuthorization helper function for the tests
 func (s *systemtestSuite) deleteAuthorization(c *C, authzUUID, token string) {
-	endpoint := "/api/v1/auth_proxy/authorizations/" + authzUUID
+	endpoint := proxy.V1Prefix + "/authorizations/" + authzUUID
 
 	resp, _ := proxyDelete(c, token, endpoint)
 	c.Assert(resp.StatusCode, Equals, 204)

--- a/systemtests/ldap_management_test.go
+++ b/systemtests/ldap_management_test.go
@@ -1,12 +1,15 @@
 package systemtests
 
-import . "gopkg.in/check.v1"
+import (
+	"github.com/contiv/auth_proxy/proxy"
+	. "gopkg.in/check.v1"
+)
 
 // TODO: add system tests to test LDAP management CRUD operations
 
 // addLdapConfiguration helper function for the tests
 func (s *systemtestSuite) addLdapConfiguration(c *C, token, data string) {
-	endpoint := "/api/v1/auth_proxy/ldap_configuration"
+	endpoint := proxy.V1Prefix + "/ldap_configuration"
 
 	resp, _ := proxyPost(c, token, endpoint, []byte(data))
 	c.Assert(resp.StatusCode, Equals, 201)
@@ -14,7 +17,7 @@ func (s *systemtestSuite) addLdapConfiguration(c *C, token, data string) {
 
 // deleteLdapConfiguration helper function for the tests
 func (s *systemtestSuite) deleteLdapConfiguration(c *C, token string) {
-	endpoint := "/api/v1/auth_proxy/ldap_configuration"
+	endpoint := proxy.V1Prefix + "/ldap_configuration"
 
 	resp, body := proxyDelete(c, token, endpoint)
 	c.Assert(resp.StatusCode, Equals, 204)

--- a/systemtests/local_user_test.go
+++ b/systemtests/local_user_test.go
@@ -2,6 +2,7 @@ package systemtests
 
 import (
 	"github.com/contiv/auth_proxy/common/types"
+	"github.com/contiv/auth_proxy/proxy"
 	. "gopkg.in/check.v1"
 )
 
@@ -27,7 +28,7 @@ func (s *systemtestSuite) TestLocalUserEndpoints(c *C) {
 		token := adminToken(c)
 
 		for _, username := range newUsers {
-			endpoint := "/api/v1/auth_proxy/local_users"
+			endpoint := proxy.V1Prefix + "/local_users"
 			resp, body := proxyGet(c, token, endpoint)
 			c.Assert(resp.StatusCode, Equals, 200)
 			c.Assert(len(body), Not(Equals), 0)
@@ -38,7 +39,7 @@ func (s *systemtestSuite) TestLocalUserEndpoints(c *C) {
 			s.addLocalUser(c, data, respBody, token)
 
 			// get `username`
-			endpoint = "/api/v1/auth_proxy/local_users/" + username
+			endpoint = proxy.V1Prefix + "/local_users/" + username
 			resp, body = proxyGet(c, token, endpoint)
 			c.Assert(resp.StatusCode, Equals, 200)
 			c.Assert(string(body), DeepEquals, respBody)
@@ -156,7 +157,7 @@ func (s *systemtestSuite) TestLocalUserDeleteEndpoint(c *C) {
 			respBody := `{"username":"` + username + `","first_name":"","last_name":"","disable":false}`
 			s.addLocalUser(c, data, respBody, token)
 
-			endpoint := "/api/v1/auth_proxy/local_users/" + username
+			endpoint := proxy.V1Prefix + "/local_users/" + username
 
 			// delete `username`
 			resp, body := proxyDelete(c, token, endpoint)
@@ -171,7 +172,7 @@ func (s *systemtestSuite) TestLocalUserDeleteEndpoint(c *C) {
 
 		// delete built-in users
 		for _, username := range builtInUsers {
-			endpoint := "/api/v1/auth_proxy/local_users/" + username
+			endpoint := proxy.V1Prefix + "/local_users/" + username
 
 			// delete `username`
 			resp, body := proxyDelete(c, token, endpoint)
@@ -188,7 +189,7 @@ func (s *systemtestSuite) TestLocalUserDeleteEndpoint(c *C) {
 
 // addLocalUser helper function for the tests
 func (s *systemtestSuite) addLocalUser(c *C, data, expectedRespBody, token string) {
-	endpoint := "/api/v1/auth_proxy/local_users"
+	endpoint := proxy.V1Prefix + "/local_users"
 
 	resp, body := proxyPost(c, token, endpoint, []byte(data))
 	c.Assert(resp.StatusCode, Equals, 201)
@@ -197,7 +198,7 @@ func (s *systemtestSuite) addLocalUser(c *C, data, expectedRespBody, token strin
 
 // updateLocalUser helper function for the tests
 func (s *systemtestSuite) updateLocalUser(c *C, username, data, expectedRespBody, token string) {
-	endpoint := "/api/v1/auth_proxy/local_users/" + username
+	endpoint := proxy.V1Prefix + "/local_users/" + username
 
 	resp, body := proxyPatch(c, token, endpoint, []byte(data))
 	c.Assert(resp.StatusCode, Equals, 200)

--- a/systemtests/rbac_test.go
+++ b/systemtests/rbac_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/contiv/auth_proxy/proxy"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -407,7 +409,7 @@ func (s *systemtestSuite) addUser(c *C, username string) {
 	runTest(func(ms *MockServer) {
 		adToken = adminToken(c)
 
-		endpoint := "/api/v1/auth_proxy/local_users/" + username
+		endpoint := proxy.V1Prefix + "/local_users/" + username
 		resp, _ := proxyGet(c, adToken, endpoint)
 		if resp.StatusCode == 200 {
 			resp, body := proxyDelete(c, adToken, endpoint)
@@ -481,7 +483,7 @@ func (s *systemtestSuite) TestAdminRoleRequired(c *C) {
 		// try calling an admin api (e.g., update user) using test user token
 		// This should fail with forbidden since user doesn't have admin access
 		data := `{"first_name":"Temp", "last_name": "User"}`
-		endpoint := "/api/v1/auth_proxy/local_users/" + username
+		endpoint := proxy.V1Prefix + "/local_users/" + username
 		resp, _ := proxyPatch(c, testuserToken, endpoint, []byte(data))
 		c.Assert(resp.StatusCode, Equals, 403)
 
@@ -499,7 +501,7 @@ func (s *systemtestSuite) TestAdminRoleRequired(c *C) {
 
 		// calling admin api should fail again withouth requiring new token (since cached value
 		// of role authz in token isn't used)
-		endpoint = "/api/v1/auth_proxy/local_users/" + username
+		endpoint = proxy.V1Prefix + "/local_users/" + username
 		resp, _ = proxyPatch(c, testuserToken, endpoint, []byte(data))
 		c.Assert(resp.StatusCode, Equals, 403)
 	})


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>