### PR TITLE
Re-enable LDAP system tests + Test LDAP StartTLS() + Fixes

### DIFF
--- a/auth/ldap/ldap.go
+++ b/auth/ldap/ldap.go
@@ -218,8 +218,9 @@ func (lm *Manager) connect() (*ldap.Conn, error) {
 	}
 
 	// switch to TLS if specified; this needs to have certs in place
-	// TODO: yet to be tested
 	if lm.Config.StartTLS {
+		log.Info("Upgrading to TLS mode")
+		// NOTE: InsecureSkipVerify should be used only for testing
 		err = ldapConn.StartTLS(&tls.Config{InsecureSkipVerify: lm.Config.InsecureSkipVerify})
 		if err != nil {
 			log.Errorf("Failed to initiate TLS with AD server: %v", err)

--- a/proxy/helpers.go
+++ b/proxy/helpers.go
@@ -72,7 +72,7 @@ func updateLdapConfigurationInfo(ldapConfiguration *types.LdapConfiguration, act
 		ldapConfigurationUpdateObj.InsecureSkipVerify = ldapConfiguration.InsecureSkipVerify
 	}
 
-	err := db.UpdateLdapConfiguration(ldapConfigurationUpdateObj)
+	err := db.UpdateLdapConfiguration(ldapConfigurationUpdateObj, actual.ServiceAccountPassword)
 
 	switch err {
 	case nil:
@@ -86,8 +86,8 @@ func updateLdapConfigurationInfo(ldapConfiguration *types.LdapConfiguration, act
 	case auth_errors.ErrKeyNotFound:
 		return http.StatusNotFound, nil
 	default:
-		log.Debugf("Failed to delete LDAP configuration: %#v", err)
-		return http.StatusInternalServerError, []byte("Failed to delete LDAP setting from the data store")
+		log.Debugf("Failed to update LDAP configuration: %#v", err)
+		return http.StatusInternalServerError, []byte("Failed to update LDAP settings to the data store")
 	}
 
 }
@@ -109,7 +109,7 @@ func updateLdapConfigurationHelper(ldapConfiguration *types.LdapConfiguration) (
 		return http.StatusNotFound, nil
 	default:
 		log.Debugf("Failed to retrieve LDAP configuration: %#v", err)
-		return http.StatusInternalServerError, []byte("Failed to retrieve LDAP setting from the data store")
+		return http.StatusInternalServerError, []byte("Failed to update LDAP settings to the data store")
 	}
 
 }

--- a/systemtests/basic_test.go
+++ b/systemtests/basic_test.go
@@ -61,22 +61,18 @@ func (s *systemtestSuite) TestLogin(c *C) {
 
 		s.addLdapConfiguration(c, adToken, ldapConfig)
 
-		// TODO: these tests have been disabled for now because all our
-		//       LDAP logins are failing for some reason.  something
-		//       might be wrong with the AD VM.
+		// try logging in using `service` account
+		loginAs(c, "saccount", ldapPassword)
 
-		// // try logging in using `service` account
-		// loginAs(c, "saccount", ldapPassword)
+		// try logging in using `temp` account; this fails as the user is only associated with primary group
+		// more details can be found here: auth/ldap/ldap.go
+		token, resp, err := login("temp", ldapPassword)
+		c.Assert(token, Equals, "")
+		c.Assert(resp.StatusCode, Equals, 401)
+		c.Assert(err, IsNil)
 
-		// // try logging in using `temp` account; this fails as the user is only associated with primary group
-		// // more details can be found here: auth/ldap/ldap.go
-		// token, resp, err := login("temp", ldapPassword)
-		// c.Assert(token, Equals, "")
-		// c.Assert(resp.StatusCode, Equals, 401)
-		// c.Assert(err, IsNil)
-
-		// // try logging in using `admin` account
-		// loginAs(c, "Administrator", ldapAdminPassword)
+		// try logging in using `admin` account
+		loginAs(c, "Administrator", ldapAdminPassword)
 
 		s.deleteLdapConfiguration(c, adToken)
 	})


### PR DESCRIPTION
Windows VM kept shutting because of the expired license(which caused the tests to fail). 

Below are the changes made to the AD VM:
1. Extended the license for another 30 days as suggested here https://github.com/xdissent/ievms/issues/22 (Seems to be working fine)
2. Enabled LDAP over SSL so we can test SSL/TLS connections.

This PR also contains fixes for the bugs(LDAP config update) identified during testing.

Signed-off-by: Yuva Shankar <yuva29@users.noreply.github.com>