### PR TITLE
Systemtests to test RBAC on LDAP user + Fixes 

### DIFF
--- a/auth/policy.go
+++ b/auth/policy.go
@@ -33,7 +33,7 @@ func (authZ *Token) getPrincipals() ([]string, error) {
 	}
 
 	// Deserialize principals as a slice
-	principals := strings.Split(principalsStr, ",")
+	principals := strings.Split(principalsStr, ";")
 	return principals, nil
 }
 

--- a/auth/token.go
+++ b/auth/token.go
@@ -90,7 +90,7 @@ func NewTokenWithClaims(principals []string) (*Token, error) {
 //  error: nil if successful, else relevant error if claim is malformed.
 func (authZ *Token) AddPrincipalsClaim(principals []string) error {
 	// Serialize principals slice as a single string
-	authZ.AddClaim(principalsClaimKey, strings.Join(principals, ","))
+	authZ.AddClaim(principalsClaimKey, strings.Join(principals, ";"))
 	return nil
 }
 
@@ -283,7 +283,7 @@ func (authZ *Token) GetClaim(claimKey string) string {
 func (authZ *Token) IsSuperuser() bool {
 
 	// Deserialize principals as a slice
-	principals := strings.Split(authZ.GetClaim(principalsClaimKey), ",")
+	principals := strings.Split(authZ.GetClaim(principalsClaimKey), ";")
 
 	for _, p := range principals {
 		// Get role claim for the principal

--- a/systemtests/basic_test.go
+++ b/systemtests/basic_test.go
@@ -16,6 +16,7 @@ const (
 	ldapServer        = "10.193.231.158"
 	ldapPassword      = "C1ntainer$"
 	ldapAdminPassword = "C1ntainer$~"
+	ldapTestUsername  = "test_user"
 
 	// use this when testing unauthenticated endpoints instead of ""
 	noToken = ""
@@ -51,15 +52,7 @@ func (s *systemtestSuite) TestLogin(c *C) {
 		adToken := adminToken(c)
 
 		// add LDAP configuration
-		ldapConfig := `{"server":"` + ldapServer + `",` +
-			`"port":5678,` +
-			`"base_dn":"DC=ccn,DC=example,DC=com",` +
-			`"service_account_dn":"CN=Service Account,CN=Users,DC=ccn,DC=example,DC=com",` +
-			`"service_account_password":"` + ldapPassword + `",` +
-			`"start_tls":false,` +
-			`"insecure_skip_verify":true}`
-
-		s.addLdapConfiguration(c, adToken, ldapConfig)
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
 
 		// try logging in using `service` account
 		loginAs(c, "saccount", ldapPassword)
@@ -75,7 +68,7 @@ func (s *systemtestSuite) TestLogin(c *C) {
 		loginAs(c, "Administrator", ldapAdminPassword)
 
 		// test login using SSL/TLS
-		ldapConfig = `{"port":5678, "start_tls":true, "insecure_skip_verify":true}`
+		ldapConfig := `{"port":5678, "start_tls":true, "insecure_skip_verify":true}`
 		s.updateLdapConfiguration(c, adToken, ldapConfig)
 
 		// try logging in using `service` account
@@ -231,4 +224,14 @@ func (s *systemtestSuite) TestPOSTBody(c *C) {
 		_, responseBody := proxyPost(c, token, endpoint, []byte(data))
 		c.Assert(string(responseBody), Equals, data)
 	})
+}
+
+func (s *systemtestSuite) getRunningLdapConfig() string {
+	return `{"server":"` + ldapServer + `",` +
+		`"port":5678,` +
+		`"base_dn":"DC=ccn,DC=example,DC=com",` +
+		`"service_account_dn":"CN=Service Account,CN=Users,DC=ccn,DC=example,DC=com",` +
+		`"service_account_password":"` + ldapPassword + `",` +
+		`"start_tls":false,` +
+		`"insecure_skip_verify":true}`
 }


### PR DESCRIPTION
This PR contains

1. Principal string separator had to be changed as the LDAP group names also contains `,`. 
2. Now, all the RBAC tests run for both local and LDAP user.

Signed-off-by: Yuva Shankar <yuva29@users.noreply.github.com>