### PR TITLE
Support TLS/SSL connection with LDAP/AD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ checks:
 # ci does everything necessary for a Github PR-triggered CI run.
 # currently, this means building a container image and running
 # all of the available tests.
-ci: build test
+ci: generate-certificate build test
 
 # generate-certificate generates a local key and cert for running the proxy.
 # if an existing certificate and key exist, it will do nothing.

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get -y upgrade && \
+          apt-get -y install curl build-essential docker.io
+
+RUN curl -O https://storage.googleapis.com/golang/go1.7.5.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.7.5.linux-amd64.tar.gz && rm go1.7.5.linux-amd64.tar.gz
+
+ENV PATH="/usr/local/go/bin:$PATH"
+ENV GOPATH="/go"
+
+RUN mkdir -p /go/src/github.com/contiv/auth_proxy
+
+WORKDIR /go/src/github.com/contiv/auth_proxy
+
+ENTRYPOINT ["/bin/bash"]

--- a/build/Dockerfile.unittests
+++ b/build/Dockerfile.unittests
@@ -1,7 +1,5 @@
-FROM golang:1.7.5
+FROM auth_proxy_build_base
 
 COPY ./ /go/src/github.com/contiv/auth_proxy
-
-WORKDIR /go/src/github.com/contiv/auth_proxy
 
 ENTRYPOINT ["/bin/bash", "./scripts/unittests_in_container.sh"]

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -87,6 +87,13 @@ type LocalUser struct {
 //                    account to communicate with LDAP/AD. Hence this account
 //                    must have appropriate privileges, specifically for lookup.
 //  ServiceAccountPassword: of the service account
+//  StartTLS: if set, the connection will be upgrated to SSL/TLS mode
+//  InsecureSkipVerify: if set, the certificate verification is skipped;
+//                      used only when `StartTLS` is enabled.
+//  TLSCertIssuedTo: Servername for which the TLS/SSL certificate was issued.
+//                   This is used only when `StartTLS` is enabled.
+//                   The connection is prone to man-in-the-middle attacks,
+//                   if empty(TLSCertIssuedTo) and InsecureSkipVerify == false.
 type LdapConfiguration struct {
 	Server                 string `json:"server"`
 	Port                   uint16 `json:"port"`
@@ -95,6 +102,7 @@ type LdapConfiguration struct {
 	ServiceAccountPassword string `json:"service_account_password,omitempty"`
 	StartTLS               bool   `json:"start_tls"`
 	InsecureSkipVerify     bool   `json:"insecure_skip_verify"`
+	TLSCertIssuedTo        string `json:"tls_cert_issued_to"`
 }
 
 //

--- a/scripts/unittests.sh
+++ b/scripts/unittests.sh
@@ -23,6 +23,7 @@ IMAGE_NAME="auth_proxy_unittests"
 NETWORK_NAME="$IMAGE_NAME"
 
 echo "Building unittests image..."
+docker build -t "auth_proxy_build_base" -f ./build/Dockerfile.base .
 docker build -t $IMAGE_NAME -f ./build/Dockerfile.unittests .
 
 function ip_for_container {

--- a/systemtests/rbac_test.go
+++ b/systemtests/rbac_test.go
@@ -73,7 +73,7 @@ func (s *systemtestSuite) TestRBACFilters(c *C) {
 			s.testRBACFiltersHelper(c, loginAs(c, username, username), username, resource, true)
 
 			// test using ldap user
-			s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+			s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 			s.testRBACFiltersHelper(c, loginAs(c, ldapTestUsername, ldapPassword), ldapGroupDN, resource, false)
 			s.deleteLdapConfiguration(c, adToken)
 		}
@@ -83,7 +83,7 @@ func (s *systemtestSuite) TestRBACFilters(c *C) {
 	// test adminOnly list endpoints
 	runTest(func(ms *MockServer) {
 
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 
 		for resource := range adminEpSuffixes {
 			endpoint := "/api/v1/" + resource + "/"
@@ -126,7 +126,7 @@ func (s *systemtestSuite) TestRBACOnDELETERequest(c *C) {
 		s.testRBACHelper(c, loginAs(c, username, username), username, endpoint, respData, "DELETE", true)
 
 		// test using ldap user
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 		s.testRBACHelper(c, loginAs(c, ldapTestUsername, ldapPassword), ldapGroupDN, endpoint, respData, "DELETE", false)
 		s.deleteLdapConfiguration(c, adToken)
 
@@ -135,7 +135,7 @@ func (s *systemtestSuite) TestRBACOnDELETERequest(c *C) {
 	// test all other endpoints
 	runTest(func(ms *MockServer) {
 
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 
 		for resource, rName := range epSuffixes {
 			endpoint := "/api/v1/" + resource + "/" + rName + "/"
@@ -160,7 +160,7 @@ func (s *systemtestSuite) TestRBACOnDELETERequest(c *C) {
 	// test adminOnly list endpoints
 	runTest(func(ms *MockServer) {
 
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 
 		for resource, rName := range adminEpSuffixes {
 			endpoint := "/api/v1/" + resource + "/" + rName + "/"
@@ -205,7 +205,7 @@ func (s *systemtestSuite) TestRBACOnGETRequest(c *C) {
 		s.testRBACHelper(c, loginAs(c, username, username), username, endpoint, respData, "GET", true)
 
 		// test using ldap user
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 		s.testRBACHelper(c, loginAs(c, ldapTestUsername, ldapPassword), ldapGroupDN, endpoint, respData, "GET", false)
 
 		// GET on unauthorized tenant
@@ -223,7 +223,7 @@ func (s *systemtestSuite) TestRBACOnGETRequest(c *C) {
 	// test all other netmaster endpoints
 	runTest(func(ms *MockServer) {
 
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 
 		for resource, rName := range epSuffixes {
 			endpoint := "/api/v1/" + resource + "/" + rName + "/"
@@ -248,7 +248,7 @@ func (s *systemtestSuite) TestRBACOnGETRequest(c *C) {
 	// test adminOnly list endpoints
 	runTest(func(ms *MockServer) {
 
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 
 		for resource, rName := range adminEpSuffixes {
 			endpoint := "/api/v1/" + resource + "/" + rName + "/"
@@ -300,7 +300,7 @@ func (s *systemtestSuite) TestRBACOnPOSTRequest(c *C) {
 		s.testRBACHelper(c, loginAs(c, username, username), username, endpoint, tenantCreateReq, "POST", true)
 
 		// test using ldap user
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 		s.testRBACHelper(c, loginAs(c, ldapTestUsername, ldapPassword), ldapGroupDN, endpoint, tenantCreateReq, "POST", false)
 		s.deleteLdapConfiguration(c, adToken)
 
@@ -309,7 +309,7 @@ func (s *systemtestSuite) TestRBACOnPOSTRequest(c *C) {
 	// test all other netmaster endpoints
 	runTest(func(ms *MockServer) {
 
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 
 		for resource, rName := range epSuffixes {
 			endpoint := "/api/v1/" + resource + "/" + rName + "/"
@@ -343,7 +343,7 @@ func (s *systemtestSuite) TestRBACOnPOSTRequest(c *C) {
 	// test adminOnly list endpoints
 	runTest(func(ms *MockServer) {
 
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 
 		for resource, rName := range adminEpSuffixes {
 			endpoint := "/api/v1/" + resource + "/" + rName + "/"
@@ -392,7 +392,7 @@ func (s *systemtestSuite) TestRBACOnGlobalEndpoint(c *C) {
 		c.Assert(string(body), DeepEquals, string(respData))
 
 		// test using ldap user
-		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig())
+		s.addLdapConfiguration(c, adToken, s.getRunningLdapConfig(true))
 		resp, body = proxyGet(c, loginAs(c, ldapTestUsername, ldapPassword), endpoint)
 		c.Assert(resp.StatusCode, Equals, 200)
 		c.Assert(string(body), DeepEquals, string(respData))

--- a/test/active_directory/ca.crt
+++ b/test/active_directory/ca.crt
@@ -1,0 +1,83 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            50:25:48:d3:cb:1b:19:ac:44:6c:6c:50:44:2e:32:69
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: DC=com, DC=example, DC=ccn, CN=ccn-WIN-CA
+        Validity
+            Not Before: Feb  9 22:43:04 2017 GMT
+            Not After : Feb  9 22:53:04 2022 GMT
+        Subject: DC=com, DC=example, DC=ccn, CN=ccn-WIN-CA
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c5:5e:0b:76:41:36:fa:0d:14:9b:cc:e5:27:ef:
+                    dd:3f:db:04:c8:d1:06:c0:c6:69:5d:d3:32:4b:20:
+                    66:8a:39:31:dd:c0:3b:f1:fb:51:38:c5:62:ea:d6:
+                    b3:7a:88:05:30:c5:02:2c:f5:92:52:e3:f8:db:4e:
+                    61:f5:0b:e7:60:cc:42:94:53:cd:82:70:5e:c5:ba:
+                    c9:24:0d:77:0c:c2:c6:4a:15:b6:68:b6:68:7e:c8:
+                    87:d3:a0:81:c0:d4:c2:fe:02:3a:b4:37:39:e6:30:
+                    47:11:70:86:f2:07:7d:3f:cb:9c:61:5d:91:2b:95:
+                    fd:ba:ff:18:97:45:1b:74:12:9b:b1:2a:a5:8c:bb:
+                    b8:c2:90:f2:b7:50:d4:de:f7:9a:b1:e8:ba:51:ed:
+                    e8:48:fb:af:c0:53:7b:d2:22:51:57:02:16:cb:22:
+                    27:ff:5a:e9:ec:01:c9:5c:e4:c1:61:90:51:99:79:
+                    2b:7f:00:19:16:12:d2:ad:8b:eb:68:1b:d7:17:22:
+                    52:da:24:17:1e:3f:ac:dd:d6:98:9c:52:f6:d9:41:
+                    44:05:a3:57:8f:28:85:a0:97:84:4d:ae:96:4e:e7:
+                    d2:cb:c7:da:4d:ef:c8:ee:f3:65:d1:2c:b7:a9:98:
+                    59:2a:11:0c:88:7a:9e:da:f1:6f:4d:26:ad:15:60:
+                    fd:81
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            1.3.6.1.4.1.311.20.2: 
+                ...C.A
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier: 
+                D1:C7:69:2C:79:3B:BF:5A:D2:BB:A4:D7:AD:DB:FD:4A:AA:D1:12:08
+            1.3.6.1.4.1.311.21.1: 
+                ...
+    Signature Algorithm: sha1WithRSAEncryption
+         05:2f:b3:60:98:68:bb:2e:df:15:9f:cb:14:b3:d4:21:b6:51:
+         b5:56:f0:9d:e6:40:12:a7:78:d6:57:a6:93:e6:dd:c1:eb:ff:
+         f7:c0:e8:b1:f2:e6:11:0f:d9:ed:e2:b9:ec:99:8c:39:98:a2:
+         7c:b0:51:31:39:7a:c5:cc:49:71:18:34:48:5e:46:20:fd:1e:
+         8d:6d:9d:ec:a7:5d:0e:b9:26:d0:58:cc:07:0e:1a:bd:53:f9:
+         cd:e0:65:50:4b:37:a2:5b:5e:6e:9a:48:5b:86:ed:5b:da:55:
+         e3:68:f2:9c:7b:b0:d4:4c:39:cc:e1:6e:99:fa:8a:b3:0d:6d:
+         ac:30:ed:c9:fb:b8:df:01:aa:33:f9:19:f7:a7:a0:00:2b:ec:
+         1c:74:cf:85:7c:ac:42:43:37:b8:6b:66:b9:e7:17:7f:39:2c:
+         10:53:56:be:85:c4:8d:fe:55:0a:53:20:4f:eb:b6:83:56:75:
+         9c:7a:7f:1a:5b:2a:7a:da:f5:44:57:40:67:8f:6b:20:76:0b:
+         a5:37:f3:89:1b:64:01:44:73:11:24:d9:03:c3:50:2e:1d:48:
+         ea:59:f9:fc:39:b6:c2:46:18:78:ff:a1:1b:5f:37:b3:f2:c7:
+         c5:7e:2b:c5:1a:48:22:b1:d9:c1:a6:97:60:40:cb:ed:2c:7b:
+         25:12:5a:ab
+-----BEGIN CERTIFICATE-----
+MIIDozCCAougAwIBAgIQUCVI08sbGaxEbGxQRC4yaTANBgkqhkiG9w0BAQUFADBY
+MRMwEQYKCZImiZPyLGQBGRYDY29tMRcwFQYKCZImiZPyLGQBGRYHZXhhbXBsZTET
+MBEGCgmSJomT8ixkARkWA2NjbjETMBEGA1UEAxMKY2NuLVdJTi1DQTAeFw0xNzAy
+MDkyMjQzMDRaFw0yMjAyMDkyMjUzMDRaMFgxEzARBgoJkiaJk/IsZAEZFgNjb20x
+FzAVBgoJkiaJk/IsZAEZFgdleGFtcGxlMRMwEQYKCZImiZPyLGQBGRYDY2NuMRMw
+EQYDVQQDEwpjY24tV0lOLUNBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAxV4LdkE2+g0Um8zlJ+/dP9sEyNEGwMZpXdMySyBmijkx3cA78ftROMVi6taz
+eogFMMUCLPWSUuP4205h9QvnYMxClFPNgnBexbrJJA13DMLGShW2aLZofsiH06CB
+wNTC/gI6tDc55jBHEXCG8gd9P8ucYV2RK5X9uv8Yl0UbdBKbsSqljLu4wpDyt1DU
+3veasei6Ue3oSPuvwFN70iJRVwIWyyIn/1rp7AHJXOTBYZBRmXkrfwAZFhLSrYvr
+aBvXFyJS2iQXHj+s3daYnFL22UFEBaNXjyiFoJeETa6WTufSy8faTe/I7vNl0Sy3
+qZhZKhEMiHqe2vFvTSatFWD9gQIDAQABo2kwZzATBgkrBgEEAYI3FAIEBh4EAEMA
+QTAOBgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU0cdp
+LHk7v1rSu6TXrdv9SqrREggwEAYJKwYBBAGCNxUBBAMCAQAwDQYJKoZIhvcNAQEF
+BQADggEBAAUvs2CYaLsu3xWfyxSz1CG2UbVW8J3mQBKneNZXppPm3cHr//fA6LHy
+5hEP2e3iueyZjDmYonywUTE5esXMSXEYNEheRiD9Ho1tneynXQ65JtBYzAcOGr1T
++c3gZVBLN6JbXm6aSFuG7VvaVeNo8px7sNRMOczhbpn6irMNbaww7cn7uN8BqjP5
+GfenoAAr7Bx0z4V8rEJDN7hrZrnnF385LBBTVr6FxI3+VQpTIE/rtoNWdZx6fxpb
+Knra9URXQGePayB2C6U384kbZAFEcxEk2QPDUC4dSOpZ+fw5tsJGGHj/oRtfN7Py
+x8V+K8UaSCKx2cGml2BAy+0seyUSWqs=
+-----END CERTIFICATE-----


### PR DESCRIPTION
This PR contains 

1. Configure `tls.Config{...}` to avoid man-in-the-middle attacks.

2. Fix broken unit-tests

Signed-off-by: Yuva Shankar <yuva29@users.noreply.github.com>