### PR TITLE
Delete the build container's volume after build is finished

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -63,7 +63,7 @@ docker run \
 
 # copy out the binaries
 docker cp build_cntr:/go/src/github.com/contiv/auth_proxy/build/output/auth_proxy ./build/output/
-docker rm -f build_cntr
+docker rm -fv build_cntr
 
 docker build -t $IMAGE_NAME:$VERSION -f ./build/Dockerfile.release .
 echo "Created image: $IMAGE_NAME:$VERSION"


### PR DESCRIPTION
This saves about 500mb of space over the course of 10 builds according to `docker system df`