### PR TITLE
Allow all tests to run even if a test command returns a non-0 exit status

### DIFF
--- a/scripts/systemtests_in_container.sh
+++ b/scripts/systemtests_in_container.sh
@@ -2,12 +2,15 @@
 
 set -uo pipefail
 
+EXIT_CODES=()
+
 echo ""
 echo "Running systemtests against etcd"
 echo ""
 
 set -x
 PROXY_ADDRESS=$1 DATASTORE_ADDRESS="etcd://$ETCD_CONTAINER_IP:2379" go test -v -timeout 5m ./systemtests -check.v
+EXIT_CODES+=($?)
 set +x
 
 echo ""
@@ -16,4 +19,13 @@ echo ""
 
 set -x
 PROXY_ADDRESS=$2 DATASTORE_ADDRESS="consul://$CONSUL_CONTAINER_IP:8500" go test -v -timeout 5m ./systemtests -check.v
+EXIT_CODES+=($?)
 set +x
+
+for exit_code in $EXIT_CODES; do
+    if [[ "$exit_code" != "0" ]]; then
+	exit 1
+    fi
+done
+
+exit 0

--- a/scripts/unittests_in_container.sh
+++ b/scripts/unittests_in_container.sh
@@ -5,6 +5,8 @@ set -uo pipefail
 ETCD_ADDRESS="etcd://$ETCD_CONTAINER_IP:2379"
 CONSUL_ADDRESS="consul://$CONSUL_CONTAINER_IP:8500"
 
+EXIT_CODES=()
+
 echo ""
 echo "===== DB TESTS ============================================================"
 echo ""
@@ -12,11 +14,13 @@ echo ""
 echo "consul:"
 echo ""
 DATASTORE_ADDRESS=$CONSUL_ADDRESS go test -v -timeout 1m ./db -check.v
+EXIT_CODES+=($?)
 echo ""
 
 echo "etcd:"
 echo ""
 DATASTORE_ADDRESS=$ETCD_ADDRESS go test -v -timeout 1m ./db -check.v
+EXIT_CODES+=($?)
 echo ""
 
 echo ""
@@ -26,10 +30,22 @@ echo ""
 echo "etcd:"
 echo ""
 DATASTORE_ADDRESS=$ETCD_ADDRESS go test -run TestAuthZ*  -v -timeout 1m ./state -check.v
+EXIT_CODES+=($?)
 DATASTORE_ADDRESS=$ETCD_ADDRESS go test -run TestEtcd*   -v -timeout 1m ./state -check.v
+EXIT_CODES+=($?)
 echo ""
 
 echo "consul:"
 echo ""
 DATASTORE_ADDRESS=$CONSUL_ADDRESS go test -run TestConsul* -v -timeout 1m ./state -check.v
+EXIT_CODES+=($?)
 echo ""
+
+
+for exit_code in $EXIT_CODES; do
+    if [[ "$exit_code" != "0" ]]; then
+	exit 1
+    fi
+done
+
+exit 0


### PR DESCRIPTION
Basically, we want all the tests to run even if any fail.  This is basically the opposite of early aborting.

It's easy to test:  just replace the first test invocation in each script with `false` and run `make test`