### PR TITLE
Added trailing slashes to all routes to ensure consistency with netmaster's routes

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -19,13 +19,13 @@ const (
 	V1Prefix = "/api/v1/auth_proxy"
 
 	// LoginPath is the authentication endpoint on the proxy
-	LoginPath = V1Prefix + "/login"
+	LoginPath = V1Prefix + "/login/"
 
 	// HealthCheckPath is the health check endpoint on the proxy
-	HealthCheckPath = V1Prefix + "/health"
+	HealthCheckPath = V1Prefix + "/health/"
 
 	// VersionPath is the version endpoint on the proxy
-	VersionPath = V1Prefix + "/version"
+	VersionPath = V1Prefix + "/version/"
 
 	// uiDirectory is the location in the container where the baked-in UI lives
 	// and where an external UI directory can be bindmounted over using -v
@@ -265,26 +265,26 @@ func addNetmasterRoutes(s *Server, router *mux.Router) {
 // addUserMgmtRoutes adds user management routes to the mux.Router.
 // All user management routes are admin-only.
 func addUserMgmtRoutes(router *mux.Router) {
-	router.Path(V1Prefix + "/local_users").Methods("POST").HandlerFunc(adminOnly(addLocalUser))
-	router.Path(V1Prefix + "/local_users/{username}").Methods("DELETE").HandlerFunc(adminOnly(deleteLocalUser))
-	router.Path(V1Prefix + "/local_users/{username}").Methods("PATCH").HandlerFunc(authorizedUserOnly(updateLocalUser))
-	router.Path(V1Prefix + "/local_users/{username}").Methods("GET").HandlerFunc(authorizedUserOnly(getLocalUser))
-	router.Path(V1Prefix + "/local_users").Methods("GET").HandlerFunc(adminOnly(getLocalUsers))
+	router.Path(V1Prefix + "/local_users/").Methods("POST").HandlerFunc(adminOnly(addLocalUser))
+	router.Path(V1Prefix + "/local_users/{username}/").Methods("DELETE").HandlerFunc(adminOnly(deleteLocalUser))
+	router.Path(V1Prefix + "/local_users/{username}/").Methods("PATCH").HandlerFunc(authorizedUserOnly(updateLocalUser))
+	router.Path(V1Prefix + "/local_users/{username}/").Methods("GET").HandlerFunc(authorizedUserOnly(getLocalUser))
+	router.Path(V1Prefix + "/local_users/").Methods("GET").HandlerFunc(adminOnly(getLocalUsers))
 }
 
 // addAuthorizationRoutes adds authorization routes to the mux.Router
 // All authorization management routes are admin-only.
 func addAuthorizationRoutes(router *mux.Router) {
-	router.Path(V1Prefix + "/authorizations").Methods("POST").HandlerFunc(adminOnly(addAuthorization))
-	router.Path(V1Prefix + "/authorizations/{authzUUID}").Methods("DELETE").HandlerFunc(adminOnly(deleteAuthorization))
-	router.Path(V1Prefix + "/authorizations/{authzUUID}").Methods("GET").HandlerFunc(adminOnly(getAuthorization))
-	router.Path(V1Prefix + "/authorizations").Methods("GET").HandlerFunc(adminOnly(listAuthorizations))
+	router.Path(V1Prefix + "/authorizations/").Methods("POST").HandlerFunc(adminOnly(addAuthorization))
+	router.Path(V1Prefix + "/authorizations/{authzUUID}/").Methods("DELETE").HandlerFunc(adminOnly(deleteAuthorization))
+	router.Path(V1Prefix + "/authorizations/{authzUUID}/").Methods("GET").HandlerFunc(adminOnly(getAuthorization))
+	router.Path(V1Prefix + "/authorizations/").Methods("GET").HandlerFunc(adminOnly(listAuthorizations))
 }
 
 // addLdapConfigurationMgmtRoutes adds LDAP configuration management routes to mux.Router.
 func addLdapConfigurationMgmtRoutes(router *mux.Router) {
-	router.Path(V1Prefix + "/ldap_configuration").Methods("PUT").HandlerFunc(adminOnly(addLdapConfiguration))
-	router.Path(V1Prefix + "/ldap_configuration").Methods("GET").HandlerFunc(adminOnly(getLdapConfiguration))
-	router.Path(V1Prefix + "/ldap_configuration").Methods("DELETE").HandlerFunc(adminOnly(deleteLdapConfiguration))
-	router.Path(V1Prefix + "/ldap_configuration").Methods("PATCH").HandlerFunc(adminOnly(updateLdapConfiguration))
+	router.Path(V1Prefix + "/ldap_configuration/").Methods("PUT").HandlerFunc(adminOnly(addLdapConfiguration))
+	router.Path(V1Prefix + "/ldap_configuration/").Methods("GET").HandlerFunc(adminOnly(getLdapConfiguration))
+	router.Path(V1Prefix + "/ldap_configuration/").Methods("DELETE").HandlerFunc(adminOnly(deleteLdapConfiguration))
+	router.Path(V1Prefix + "/ldap_configuration/").Methods("PATCH").HandlerFunc(adminOnly(updateLdapConfiguration))
 }

--- a/scripts/systemtests.sh
+++ b/scripts/systemtests.sh
@@ -73,7 +73,6 @@ CONSUL_CONTAINER_ID=$(
 CONSUL_CONTAINER_IP=$(ip_for_container $CONSUL_CONTAINER_ID)
 echo "consul running @ $CONSUL_CONTAINER_IP:8500"
 
-
 #
 # NOTE: we start the systemtests container and then later use `docker exec` to
 #       run the tests against etcd and consul.  The reason for starting it like

--- a/systemtests/ldap_management_test.go
+++ b/systemtests/ldap_management_test.go
@@ -7,18 +7,16 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+var endpoint = proxy.V1Prefix + "/ldap_configuration" + "/"
+
 // addLdapConfiguration helper function for the tests
 func (s *systemtestSuite) addLdapConfiguration(c *C, token, data string) {
-	endpoint := proxy.V1Prefix + "/ldap_configuration"
-
 	resp, _ := proxyPut(c, token, endpoint, []byte(data))
 	c.Assert(resp.StatusCode, Equals, 201)
 }
 
 // deleteLdapConfiguration helper function for the tests
 func (s *systemtestSuite) deleteLdapConfiguration(c *C, token string) {
-	endpoint := proxy.V1Prefix + "/ldap_configuration"
-
 	resp, body := proxyDelete(c, token, endpoint)
 	c.Assert(resp.StatusCode, Equals, 204)
 	c.Assert(body, DeepEquals, []byte{})
@@ -26,8 +24,6 @@ func (s *systemtestSuite) deleteLdapConfiguration(c *C, token string) {
 
 // getLdapConfiguration helper function for the tests
 func (s *systemtestSuite) getLdapConfiguration(c *C, token string) []byte {
-	endpoint := proxy.V1Prefix + "/ldap_configuration"
-
 	resp, body := proxyGet(c, token, endpoint)
 	c.Assert(resp.StatusCode, Equals, 200)
 
@@ -36,8 +32,6 @@ func (s *systemtestSuite) getLdapConfiguration(c *C, token string) []byte {
 
 // updateLdapConfiguration helper function for the tests
 func (s *systemtestSuite) updateLdapConfiguration(c *C, token, data string) {
-	endpoint := proxy.V1Prefix + "/ldap_configuration"
-
 	resp, _ := proxyPatch(c, token, endpoint, []byte(data))
 	c.Assert(resp.StatusCode, Equals, 200)
 }
@@ -51,7 +45,6 @@ func (s *systemtestSuite) TestLdapAddEndpoint(c *C) {
 
 	runTest(func(ms *MockServer) {
 		userToken := loginAs(c, username, username)
-		endpoint := proxy.V1Prefix + "/ldap_configuration"
 
 		// test with corrupted json data
 		ldapConfig := s.getRunningLdapConfig(false)
@@ -124,7 +117,6 @@ func (s *systemtestSuite) TestLdapDeleteEndpoint(c *C) {
 	s.addUser(c, username)
 
 	runTest(func(ms *MockServer) {
-		endpoint := proxy.V1Prefix + "/ldap_configuration"
 		userToken := loginAs(c, username, username)
 		ldapConfig := s.getRunningLdapConfig(false)
 
@@ -137,7 +129,6 @@ func (s *systemtestSuite) TestLdapDeleteEndpoint(c *C) {
 		c.Assert(string(body), Matches, ".*access denied.*")
 
 		s.deleteLdapConfiguration(c, adToken)
-
 	})
 }
 
@@ -146,7 +137,6 @@ func (s *systemtestSuite) TestLdapUpdateEndpoint(c *C) {
 	s.addUser(c, username)
 
 	runTest(func(ms *MockServer) {
-		endpoint := proxy.V1Prefix + "/ldap_configuration"
 		userToken := loginAs(c, username, username)
 		ldapConfig := s.getRunningLdapConfig(false)
 
@@ -190,6 +180,5 @@ func (s *systemtestSuite) TestLdapUpdateEndpoint(c *C) {
 		c.Assert(resp.StatusCode, Equals, 200)
 
 		s.deleteLdapConfiguration(c, adToken)
-
 	})
 }

--- a/systemtests/local_user_test.go
+++ b/systemtests/local_user_test.go
@@ -32,7 +32,7 @@ func (s *systemtestSuite) TestLocalUserEndpoints(c *C) {
 
 		for _, username := range newUsers {
 			endpoint := proxy.V1Prefix + "/local_users"
-			resp, body := proxyGet(c, token, endpoint)
+			resp, body := proxyGet(c, token, endpoint+"/")
 			c.Assert(resp.StatusCode, Equals, 200)
 			c.Assert(len(body), Not(Equals), 0)
 
@@ -43,7 +43,7 @@ func (s *systemtestSuite) TestLocalUserEndpoints(c *C) {
 
 			// get `username`
 			endpoint = proxy.V1Prefix + "/local_users/" + username
-			resp, body = proxyGet(c, token, endpoint)
+			resp, body = proxyGet(c, token, endpoint+"/")
 			c.Assert(resp.StatusCode, Equals, 200)
 			c.Assert(string(body), DeepEquals, respBody)
 
@@ -52,12 +52,12 @@ func (s *systemtestSuite) TestLocalUserEndpoints(c *C) {
 			c.Assert(len(testuserToken), Not(Equals), 0)
 
 			// delete `username`
-			resp, body = proxyDelete(c, token, endpoint)
+			resp, body = proxyDelete(c, token, endpoint+"/")
 			c.Assert(resp.StatusCode, Equals, 204)
 			c.Assert(len(body), Equals, 0)
 
 			// get `username`
-			resp, body = proxyGet(c, token, endpoint)
+			resp, body = proxyGet(c, token, endpoint+"/")
 			c.Assert(resp.StatusCode, Equals, 404)
 			c.Assert(len(body), Equals, 0)
 		}
@@ -67,7 +67,7 @@ func (s *systemtestSuite) TestLocalUserEndpoints(c *C) {
 		// test usernames with special characters
 		for _, username := range invalidUsernames {
 			data := `{"username": "` + username + `", "password":"test"}`
-			resp, body := proxyPost(c, token, endpoint, []byte(data))
+			resp, body := proxyPost(c, token, endpoint+"/", []byte(data))
 			c.Assert(resp.StatusCode, Equals, http.StatusBadRequest)
 			c.Assert(string(body), Matches, ".*Invalid username.*")
 		}
@@ -182,12 +182,12 @@ func (s *systemtestSuite) TestLocalUserDeleteEndpoint(c *C) {
 			endpoint := proxy.V1Prefix + "/local_users/" + username
 
 			// delete `username`
-			resp, body := proxyDelete(c, token, endpoint)
+			resp, body := proxyDelete(c, token, endpoint+"/")
 			c.Assert(resp.StatusCode, Equals, 204)
 			c.Assert(len(body), Equals, 0)
 
 			// get `username`
-			resp, body = proxyGet(c, token, endpoint)
+			resp, body = proxyGet(c, token, endpoint+"/")
 			c.Assert(resp.StatusCode, Equals, 404)
 			c.Assert(len(body), Equals, 0)
 		}
@@ -197,12 +197,12 @@ func (s *systemtestSuite) TestLocalUserDeleteEndpoint(c *C) {
 			endpoint := proxy.V1Prefix + "/local_users/" + username
 
 			// delete `username`
-			resp, body := proxyDelete(c, token, endpoint)
+			resp, body := proxyDelete(c, token, endpoint+"/")
 			c.Assert(resp.StatusCode, Equals, 400)
 			c.Assert(len(body), Not(Equals), 0)
 
 			// get `username`
-			resp, body = proxyGet(c, token, endpoint)
+			resp, body = proxyGet(c, token, endpoint+"/")
 			c.Assert(resp.StatusCode, Equals, 200)
 			c.Assert(len(body), Not(Equals), 0)
 		}
@@ -213,7 +213,7 @@ func (s *systemtestSuite) TestLocalUserDeleteEndpoint(c *C) {
 func (s *systemtestSuite) addLocalUser(c *C, data, expectedRespBody, token string) {
 	endpoint := proxy.V1Prefix + "/local_users"
 
-	resp, body := proxyPost(c, token, endpoint, []byte(data))
+	resp, body := proxyPost(c, token, endpoint+"/", []byte(data))
 	c.Assert(resp.StatusCode, Equals, 201)
 	c.Assert(string(body), DeepEquals, expectedRespBody)
 }
@@ -222,7 +222,7 @@ func (s *systemtestSuite) addLocalUser(c *C, data, expectedRespBody, token strin
 func (s *systemtestSuite) updateLocalUser(c *C, username, data, expectedRespBody, token string) {
 	endpoint := proxy.V1Prefix + "/local_users/" + username
 
-	resp, body := proxyPatch(c, token, endpoint, []byte(data))
+	resp, body := proxyPatch(c, token, endpoint+"/", []byte(data))
 	c.Assert(resp.StatusCode, Equals, 200)
 	c.Assert(string(body), DeepEquals, expectedRespBody)
 }

--- a/systemtests/rbac_test.go
+++ b/systemtests/rbac_test.go
@@ -572,7 +572,7 @@ func (s *systemtestSuite) addUser(c *C, username string) {
 	runTest(func(ms *MockServer) {
 		adToken = adminToken(c)
 
-		endpoint := proxy.V1Prefix + "/local_users/" + username
+		endpoint := proxy.V1Prefix + "/local_users/" + username + "/"
 		resp, _ := proxyGet(c, adToken, endpoint)
 		if resp.StatusCode == 200 {
 			resp, body := proxyDelete(c, adToken, endpoint)
@@ -646,12 +646,12 @@ func (s *systemtestSuite) TestAdminRoleRequired(c *C) {
 		// update user details using his/her token
 		data := `{"first_name":"Temp", "last_name": "User"}`
 		endpoint := proxy.V1Prefix + "/local_users/" + username
-		resp, _ := proxyPatch(c, testuserToken, endpoint, []byte(data))
+		resp, _ := proxyPatch(c, testuserToken, endpoint+"/", []byte(data))
 		c.Assert(resp.StatusCode, Equals, 200)
 
 		// try updating other user details
 		endpoint = proxy.V1Prefix + "/local_users/unknown"
-		resp, _ = proxyPatch(c, testuserToken, endpoint, []byte(data))
+		resp, _ = proxyPatch(c, testuserToken, endpoint+"/", []byte(data))
 		// user is not allowed to update other user details
 		c.Assert(resp.StatusCode, Equals, 403)
 
@@ -669,7 +669,7 @@ func (s *systemtestSuite) TestAdminRoleRequired(c *C) {
 
 		// update using user's token
 		endpoint = proxy.V1Prefix + "/local_users/" + username
-		resp, _ = proxyPatch(c, testuserToken, endpoint, []byte(data))
+		resp, _ = proxyPatch(c, testuserToken, endpoint+"/", []byte(data))
 		c.Assert(resp.StatusCode, Equals, 200)
 
 		// Below tests the adminOnly api
@@ -685,7 +685,7 @@ func (s *systemtestSuite) testAdminOnlyAPI(c *C) {
 	// This should fail with forbidden since user doesn't have admin access
 	data := `{"username":"test_xyz", "password":"test", "first_name":"Temp", "last_name": "User"}`
 	endpoint := proxy.V1Prefix + "/local_users"
-	resp, _ := proxyPost(c, testuserToken, endpoint, []byte(data))
+	resp, _ := proxyPost(c, testuserToken, endpoint+"/", []byte(data))
 	c.Assert(resp.StatusCode, Equals, 403)
 
 	// grant admin access to username
@@ -702,6 +702,6 @@ func (s *systemtestSuite) testAdminOnlyAPI(c *C) {
 
 	// calling admin api should fail again without requiring new token (since cached value
 	// of role authz in token isn't used)
-	resp, _ = proxyPost(c, testuserToken, endpoint, []byte(data))
+	resp, _ = proxyPost(c, testuserToken, endpoint+"/", []byte(data))
 	c.Assert(resp.StatusCode, Equals, 403)
 }


### PR DESCRIPTION
Since we sometimes use the "endpoint" variable verbatim and we sometimes concatenate stuff onto it in the test code, it's confusing to add the trailing slashes inline in the strings.  I added them as `+ "/"` so that they're easy to identify and remove later.