### PR TITLE
Handle cases where the user account is disabled/deleted

### DIFF
--- a/proxy/rbac.go
+++ b/proxy/rbac.go
@@ -87,8 +87,8 @@ func enforceRBAC(s *Server) func(http.ResponseWriter, *http.Request) {
 
 		common.SetDefaultResponseHeaders(w)
 
-		isValid, token := isTokenValid(req.Header.Get("X-Auth-Token"), w)
-		if !isValid {
+		token, valid := validateToken(w, req)
+		if !valid {
 			return
 		}
 


### PR DESCRIPTION
This addresses one of the TODO items. Once the user is disabled/deleted, the associated token is no more valid.

Also, this consolidates `parseReqToken` and `isTokenValid` functions ==> `validateToken`

Signed-off-by: Yuva Shankar <yuva29@users.noreply.github.com>