### PR TITLE
Use mlockall(2) to prevent pages from being swapped

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/blang/semver"
@@ -191,6 +192,9 @@ func netmasterStartupCheck() error {
 }
 
 func main() {
+
+	// prevent this process from being swapped out to disk
+	syscall.Mlockall(syscall.MCL_CURRENT | syscall.MCL_FUTURE)
 
 	log.Println(ProgramName, ProgramVersion, "starting up...")
 


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>