### PR TITLE
scripts/build_in_container.sh: switched from `strip` to -s and -w linker flags

### DIFF
--- a/scripts/build_in_container.sh
+++ b/scripts/build_in_container.sh
@@ -6,11 +6,13 @@ set -euxo pipefail
 # for our "scratch"-based final image.
 export CGO_ENABLED=0
 
+# we also set the -s and -w linker flags to strip unncessary debug info from the
+# final binary.  this is the correct way to do it.  using `strip` is not.
+# see the following for details on the flags: https://golang.org/cmd/link/
+
 # output the binary under the build/output directory from where it will be
 # `docker cp`ed into the final image.
 go build \
-	-ldflags "-X main.ProgramVersion=$VERSION" \
+	-ldflags "-s -w -X main.ProgramVersion=$VERSION" \
 	-o ./build/output/auth_proxy \
 	github.com/contiv/auth_proxy
-
-strip ./build/output/auth_proxy


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>