### PR TITLE
proxy/helpers.go: return a better message when the X-Auth-Token header is missing

### DIFF
--- a/proxy/helpers.go
+++ b/proxy/helpers.go
@@ -478,6 +478,12 @@ func validateTLSParams(ldapConfig *types.LdapConfiguration) []byte {
 //  *auth.Token: token object parsed from the tokenStr
 //  bool: boolean representing the token validatity
 func validateToken(w http.ResponseWriter, req *http.Request) (*auth.Token, bool) {
+
+	if _, ok := req.Header["X-Auth-Token"]; !ok {
+		authError(w, http.StatusBadRequest, "X-Auth-Token header is missing")
+		return nil, false
+	}
+
 	tokenStr := req.Header.Get("X-Auth-Token")
 
 	if common.IsEmpty(tokenStr) {

--- a/systemtests/basic_test.go
+++ b/systemtests/basic_test.go
@@ -27,9 +27,32 @@ const (
 //       having a package/datastore for doing local user management.
 //       See Test() in init_test.go for where that would be done.
 
+// TestTokens tests omitting the X-Auth-Token header entirely and also sending
+// in bad values.
+func (s *systemtestSuite) TestTokens(c *C) {
+
+	// test omitting token header and sending in an invalid token
+	runTest(func(ms *MockServer) {
+		endpoint := "/api/v1/networks/"
+
+		// no token
+		resp, data := proxyGet(c, noToken, endpoint)
+		c.Assert(resp.StatusCode, Equals, 400)
+		c.Assert(string(data), Matches, ".*header is missing.*")
+
+		// invalid token
+		resp, data = proxyGet(c, "asdf", endpoint)
+		c.Assert(resp.StatusCode, Equals, 400)
+		c.Assert(string(data), Matches, ".*Bad token.*")
+	})
+
+}
+
 // TestLogin tests that valid credentials successfully authenticate and that
 // invalid credentials result in failed authentication.
 func (s *systemtestSuite) TestLogin(c *C) {
+
+	// test logging in with valid and invalid credentials
 	runTest(func(ms *MockServer) {
 		//
 		// valid credentials


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>