### PR TITLE
scripts/checks.sh: rely on COPY in Dockerfile.checks rather than bindmounting

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -6,8 +6,4 @@ CHECKS_CONTAINER_NAME="auth_proxy_checks"
 
 docker build -t $CHECKS_CONTAINER_NAME -f ./build/Dockerfile.checks .
 
-# the auth_proxy directory exists in the base image, but it's empty so we'll
-# bindmount the current directory into it.
-docker run --rm \
-	-v $(pwd):/go/src/github.com/contiv/auth_proxy \
-	$CHECKS_CONTAINER_NAME
+docker run --rm $CHECKS_CONTAINER_NAME


### PR DESCRIPTION
This lets things work nicely with docker-machine and SELinux-enabled systems.

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>