### PR TITLE
build/Dockerfile.checks: use our Github fork of shfmt instead of the one on the author's personal domain

### DIFF
--- a/build/Dockerfile.checks
+++ b/build/Dockerfile.checks
@@ -5,7 +5,7 @@ RUN go get github.com/golang/lint/golint
 RUN go get github.com/fzipp/gocyclo
 RUN go get github.com/client9/misspell/...
 RUN go get github.com/remyoudompheng/go-misc/deadcode/...
-RUN go get github.com/mvdan/sh/cmd/shfmt
+RUN go get github.com/contiv-experimental/sh/cmd/shfmt
 
 COPY ./ /go/src/github.com/contiv/auth_proxy
 


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>