### PR TITLE
Separate state store driver and address

### DIFF
--- a/common/test/utils.go
+++ b/common/test/utils.go
@@ -3,7 +3,6 @@ package test
 import (
 	"os"
 	"os/exec"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -14,16 +13,16 @@ import (
 // the datastore is already empty), so we'll use "|| true" to ignore failures.
 // params:
 //  addr: address of the datastore, e.g., "etcd://w.x.y.z:2379"
-func EmptyDatastore(addr string) {
-	switch {
-	case strings.HasPrefix(addr, "etcd://"):
+func EmptyDatastore(driver string) {
+	switch driver {
+	case "etcd":
 		cmd := "docker exec " + os.Getenv("ETCD_CONTAINER_NAME") + " /etcdctl rm --recursive /auth_proxy || true"
 		log.Debugln("Emptying datastore:", cmd)
 
 		if err := exec.Command("/bin/sh", "-c", cmd).Run(); err != nil {
 			log.Fatalln("Failed to clear etcd: ", err)
 		}
-	case strings.HasPrefix(addr, "consul://"):
+	case "consul":
 		// NOTE: consul keys do not start with a /
 		cmd := "docker exec " + os.Getenv("CONSUL_CONTAINER_NAME") + " consul kv delete -recurse auth_proxy || true"
 		log.Debugln("Emptying datastore:", cmd)
@@ -32,6 +31,6 @@ func EmptyDatastore(addr string) {
 			log.Fatalln("Failed to clear consul: ", err)
 		}
 	default:
-		log.Fatalln("Unknown data store for address:", addr)
+		log.Fatalln("Unknown data store: %q", driver)
 	}
 }

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -113,7 +113,8 @@ type LdapConfiguration struct {
 //   StoreURL: URL of the key-value store
 //
 type KVStoreConfig struct {
-	StoreURL string `json:"kvstore-url"`
+	StoreURL    string `json:"kvstore-url"`
+	StoreDriver string `json:"kvstore-driver"`
 }
 
 //

--- a/db/local_test.go
+++ b/db/local_test.go
@@ -42,24 +42,30 @@ var (
 		},
 	}
 
-	invalidUsers     = []string{"xxx", "yyy", "zzz"}
-	builtInUsers     = []string{types.Admin.String(), types.Ops.String()}
-	datastoreAddress = ""
+	invalidUsers    = []string{"xxx", "yyy", "zzz"}
+	builtInUsers    = []string{types.Admin.String(), types.Ops.String()}
+	datastoreDriver = ""
 )
 
 // This runs before each test and guarantees the datastore is emptied out.
 func (s *dbSuite) SetUpTest(c *C) {
-	test.EmptyDatastore(datastoreAddress)
+	test.EmptyDatastore(datastoreDriver)
 }
 
 // SetUpSuite sets up the environment for tests.
 func (s *dbSuite) SetUpSuite(c *C) {
-	datastoreAddress = strings.TrimSpace(os.Getenv("DATASTORE_ADDRESS"))
+	datastoreAddress := strings.TrimSpace(os.Getenv("DATASTORE_ADDRESS"))
+	datastoreDriver = strings.TrimSpace(os.Getenv("DATASTORE_DRIVER"))
+
+	if datastoreDriver != state.EtcdName && datastoreDriver != state.ConsulName {
+		log.Fatalln("you must provide a DATASTORE_DRIVER (options: [etcd, consul])")
+	}
+
 	if common.IsEmpty(datastoreAddress) {
 		log.Fatalln("you must provide a DATASTORE_ADDRESS")
 	}
 
-	if err := state.InitializeStateDriver(datastoreAddress); err != nil {
+	if err := state.InitializeStateDriver(datastoreDriver, datastoreAddress); err != nil {
 		log.Fatalln(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ const (
 
 var (
 	// flags
+	dataStoreDriver  string // driver of the data store used by netmaster
 	dataStoreAddress string // address of the data store used by netmaster
 	debug            bool   // if set, log level is set to `debug`
 	listenAddress    string // address we listen on
@@ -105,6 +106,13 @@ func processFlags() {
 		"data-store-address",
 		"",
 		"address of the state store used by netmaster",
+	)
+
+	flag.StringVar(
+		&dataStoreDriver,
+		"data-store-driver",
+		"",
+		"driver of the state store used by netmaster",
 	)
 
 	flag.Parse()
@@ -211,7 +219,7 @@ func main() {
 	}
 
 	// Initialize data store
-	if err := state.InitializeStateDriver(dataStoreAddress); err != nil {
+	if err := state.InitializeStateDriver(dataStoreDriver, dataStoreAddress); err != nil {
 		log.Fatalln(err)
 		return
 	}

--- a/scripts/systemtests.sh
+++ b/scripts/systemtests.sh
@@ -101,7 +101,8 @@ ETCD_PROXY_CONTAINER_ID=$(
 		-e NO_NETMASTER_STARTUP_CHECK=true \
 		--network $NETWORK_NAME \
 		$PROXY_IMAGE \
-		--data-store-address="etcd://$ETCD_CONTAINER_IP:2379" \
+		--data-store-driver="etcd" \
+		--data-store-address="http://$ETCD_CONTAINER_IP:2379" \
 		--tls-certificate=/local_certs/cert.pem \
 		--tls-key-file=/local_certs/local.key \
 		--listen-address=0.0.0.0:10000 \
@@ -120,7 +121,8 @@ CONSUL_PROXY_CONTAINER_ID=$(
 		--network $NETWORK_NAME \
 		-e NO_NETMASTER_STARTUP_CHECK=true \
 		$PROXY_IMAGE \
-		--data-store-address="consul://$CONSUL_CONTAINER_IP:8500" \
+		--data-store-driver="consul" \
+		--data-store-address="http://$CONSUL_CONTAINER_IP:8500" \
 		--tls-certificate=/local_certs/cert.pem \
 		--tls-key-file=/local_certs/local.key \
 		--listen-address=0.0.0.0:10001 \

--- a/scripts/systemtests_in_container.sh
+++ b/scripts/systemtests_in_container.sh
@@ -9,7 +9,7 @@ echo "Running systemtests against etcd"
 echo ""
 
 set -x
-PROXY_ADDRESS=$1 DATASTORE_ADDRESS="etcd://$ETCD_CONTAINER_IP:2379" go test -v -timeout 5m ./systemtests -check.v
+PROXY_ADDRESS=$1 DATASTORE_DRIVER=etcd DATASTORE_ADDRESS="http://$ETCD_CONTAINER_IP:2379" go test -v -timeout 5m ./systemtests -check.v
 EXIT_CODES+=($?)
 set +x
 
@@ -18,7 +18,7 @@ echo "Running systemtests against consul"
 echo ""
 
 set -x
-PROXY_ADDRESS=$2 DATASTORE_ADDRESS="consul://$CONSUL_CONTAINER_IP:8500" go test -v -timeout 5m ./systemtests -check.v
+PROXY_ADDRESS=$2 DATASTORE_DRIVER=consul DATASTORE_ADDRESS="http://$CONSUL_CONTAINER_IP:8500" go test -v -timeout 5m ./systemtests -check.v
 EXIT_CODES+=($?)
 set +x
 

--- a/scripts/unittests_in_container.sh
+++ b/scripts/unittests_in_container.sh
@@ -2,8 +2,8 @@
 
 set -uo pipefail
 
-ETCD_ADDRESS="etcd://$ETCD_CONTAINER_IP:2379"
-CONSUL_ADDRESS="consul://$CONSUL_CONTAINER_IP:8500"
+ETCD_ADDRESS="http://$ETCD_CONTAINER_IP:2379"
+CONSUL_ADDRESS="http://$CONSUL_CONTAINER_IP:8500"
 
 EXIT_CODES=()
 
@@ -13,13 +13,13 @@ echo ""
 
 echo "consul:"
 echo ""
-DATASTORE_ADDRESS=$CONSUL_ADDRESS go test -v -timeout 1m ./db -check.v
+DATASTORE_DRIVER=consul DATASTORE_ADDRESS=$CONSUL_ADDRESS go test -v -timeout 1m ./db -check.v
 EXIT_CODES+=($?)
 echo ""
 
 echo "etcd:"
 echo ""
-DATASTORE_ADDRESS=$ETCD_ADDRESS go test -v -timeout 1m ./db -check.v
+DATASTORE_DRIVER=etcd DATASTORE_ADDRESS=$ETCD_ADDRESS go test -v -timeout 1m ./db -check.v
 EXIT_CODES+=($?)
 echo ""
 
@@ -29,15 +29,15 @@ echo ""
 
 echo "etcd:"
 echo ""
-DATASTORE_ADDRESS=$ETCD_ADDRESS go test -run TestAuthZ* -v -timeout 1m ./state -check.v
+DATASTORE_DRIVER=etcd DATASTORE_ADDRESS=$ETCD_ADDRESS go test -run TestAuthZ* -v -timeout 1m ./state -check.v
 EXIT_CODES+=($?)
-DATASTORE_ADDRESS=$ETCD_ADDRESS go test -run TestEtcd* -v -timeout 1m ./state -check.v
+DATASTORE_DRIVER=etcd DATASTORE_ADDRESS=$ETCD_ADDRESS go test -run TestEtcd* -v -timeout 1m ./state -check.v
 EXIT_CODES+=($?)
 echo ""
 
 echo "consul:"
 echo ""
-DATASTORE_ADDRESS=$CONSUL_ADDRESS go test -run TestConsul* -v -timeout 1m ./state -check.v
+DATASTORE_DRIVER=consul DATASTORE_ADDRESS=$CONSUL_ADDRESS go test -run TestConsul* -v -timeout 1m ./state -check.v
 EXIT_CODES+=($?)
 echo ""
 

--- a/state/authz_test.go
+++ b/state/authz_test.go
@@ -19,7 +19,8 @@ var (
 func TestAuthZInit(t *testing.T) {
 	// create config for KV store
 	config = types.KVStoreConfig{
-		StoreURL: os.Getenv("DATASTORE_ADDRESS"),
+		StoreURL:    os.Getenv("DATASTORE_ADDRESS"),
+		StoreDriver: os.Getenv("DATASTORE_Driver"),
 	}
 
 	// create a state driver

--- a/state/consulstatedriver_test.go
+++ b/state/consulstatedriver_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func setupConsulDriver(t *testing.T) *ConsulStateDriver {
-	config := types.KVStoreConfig{StoreURL: os.Getenv("DATASTORE_ADDRESS")}
+	config := types.KVStoreConfig{
+		StoreURL:    os.Getenv("DATASTORE_ADDRESS"),
+		StoreDriver: os.Getenv("DATASTORE_DRIVER"),
+	}
 
 	driver := &ConsulStateDriver{}
 

--- a/state/driverfactory.go
+++ b/state/driverfactory.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/contiv/auth_proxy/common"
 	auth_errors "github.com/contiv/auth_proxy/common/errors"
@@ -99,18 +98,14 @@ func GetStateDriver() (types.StateDriver, error) {
 //  dataStoreAddress: address of the data store
 // return values:
 //  returns any error as NewStateDriver() + validation errors
-func InitializeStateDriver(dataStoreAddress string) error {
+func InitializeStateDriver(dataStoreDriver, dataStoreAddress string) error {
+	if dataStoreDriver != EtcdName && dataStoreDriver != ConsulName {
+		return errors.New("Invalid data store driver, please set --data-store-driver (options: [etcd, consul])")
+	}
 	if common.IsEmpty(dataStoreAddress) {
 		return errors.New("Empty data store address, please set --data-store-address")
 	}
+	_, err := NewStateDriver(dataStoreDriver, &types.KVStoreConfig{StoreURL: dataStoreAddress})
+	return err
 
-	if strings.HasPrefix(dataStoreAddress, EtcdName+"://") {
-		_, err := NewStateDriver(EtcdName, &types.KVStoreConfig{StoreURL: dataStoreAddress})
-		return err
-	} else if strings.HasPrefix(dataStoreAddress, ConsulName+"://") {
-		_, err := NewStateDriver(ConsulName, &types.KVStoreConfig{StoreURL: dataStoreAddress})
-		return err
-	}
-
-	return errors.New("Invalid data store address")
 }

--- a/state/etcdstatedriver_test.go
+++ b/state/etcdstatedriver_test.go
@@ -23,7 +23,10 @@ func Test(t *testing.T) {
 
 // Setup configuration needed to access local etcd
 func setupEtcdDriver(t *testing.T) *EtcdStateDriver {
-	config := types.KVStoreConfig{StoreURL: os.Getenv("DATASTORE_ADDRESS")}
+	config := types.KVStoreConfig{
+		StoreURL:    os.Getenv("DATASTORE_ADDRESS"),
+		StoreDriver: os.Getenv("DATASTORE_DRIVER"),
+	}
 
 	driver := &EtcdStateDriver{}
 

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -49,9 +49,10 @@ func Test(t *testing.T) {
 
 	// DATASTORE_ADDRESS is set in ./scripts/systemtests_in_container.sh
 	datastoreAddress := strings.TrimSpace(os.Getenv("DATASTORE_ADDRESS"))
+	datastoreDriver := strings.TrimSpace(os.Getenv("DATASTORE_DRIVER"))
 
 	log.Info("Initializing datastore")
-	if err := state.InitializeStateDriver(datastoreAddress); err != nil {
+	if err := state.InitializeStateDriver(datastoreDriver, datastoreAddress); err != nil {
 		log.Fatalln(err)
 	}
 


### PR DESCRIPTION
In the past, the state store driver address's schema part indicates
the state store driver type, however, it limits https endpoints.
This commit separates the driver type and address to make it align
with updated netplugin and netmaster's CLI.

Signed-off-by: Wei Tie <nuaafe@gmail.com>